### PR TITLE
changes typeof parameter in canonical function

### DIFF
--- a/functions/unique-param-names.js
+++ b/functions/unique-param-names.js
@@ -4,7 +4,7 @@
 // Return the "canonical" casing for a string.
 // Currently just lowercase but should be extended to convert kebab/camel/snake/Pascal.
 function canonical(name) {
-  return typeof (value) === 'string' ? name.toLowerCase() : name;
+  return typeof (name) === 'string' ? name.toLowerCase() : name;
 }
 
 // Accept an array and return a list of unique duplicate entries in canonical form.


### PR DESCRIPTION
the currently used `value` variable in the canonical function is
inherited from global scope and might not reference the same value as
`name` when the function is called.
`name` is scoped to the function so it is better/correct to use
`name` here.