### PR TITLE
Fix az-lro-headers to check header name case-insensitively

### DIFF
--- a/functions/has-header.js
+++ b/functions/has-header.js
@@ -1,0 +1,29 @@
+// Check a response to ensure it has a specific header.
+// Comparison must be done case-insensitively since that is the HTTP rule.
+
+module.exports = (response, opts, paths) => {
+  if (response === null || typeof response !== 'object') {
+    return [];
+  }
+
+  // opts must contain the name of the header to check for
+  if (opts === null || typeof opts !== 'object' || !opts.name) {
+    return [];
+  }
+
+  const path = paths.path || paths.target || [];
+
+  const hasHeader = Object.keys(response.headers || {})
+    .some((name) => name.toLowerCase() === opts.name.toLowerCase());
+
+  if (!hasHeader) {
+    return [
+      {
+        message: `Response should include an "${opts.name}" response header.`,
+        path: [...path, 'headers'],
+      },
+    ];
+  }
+
+  return [];
+};

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -3,6 +3,7 @@ functionsDir: './functions'
 functions:
   - consistent-response-body
   - error-response
+  - has-header
   - operation-id
   - pagination-response
   - param-names
@@ -59,12 +60,14 @@ rules:
 
   az-lro-headers:
     description: A 202 response should include an Operation-Location response header.
+    message: A 202 response should include an Operation-Location response header.
     severity: warn
     formats: ['oas2']
     given: $.paths[*][*].responses[?(@property == '202')]
     then:
-      field: headers.Operation-location
-      function: truthy
+      function: has-header
+      functionOptions:
+        name: Operation-location
 
   az-operation-id:
     description: OperationId should conform to Azure API Guidelines

--- a/test/lro-headers.test.js
+++ b/test/lro-headers.test.js
@@ -1,0 +1,114 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-lro-headers');
+  return linter;
+});
+
+test('az-lro-headers should find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        post: {
+          responses: {
+            202: {
+              description: 'Accepted',
+            },
+          },
+        },
+      },
+      '/test2': {
+        post: {
+          responses: {
+            202: {
+              description: 'Accepted',
+              headers: {
+                location: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results).toHaveLength(2);
+    expect(results[0].path.join('.')).toBe('paths./test1.post.responses.202');
+    expect(results[1].path.join('.')).toBe('paths./test2.post.responses.202.headers');
+    results.forEach((result) => expect(result.message).toBe(
+      'A 202 response should include an Operation-Location response header.',
+    ));
+  });
+});
+
+test('az-lro-headers should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        post: {
+          responses: {
+            202: {
+              description: 'Accepted',
+              headers: {
+                'Operation-location': {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+      '/test2': {
+        post: {
+          responses: {
+            202: {
+              description: 'Accepted',
+              headers: {
+                'operation-location': {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+      '/test3': {
+        post: {
+          responses: {
+            202: {
+              description: 'Accepted',
+              headers: {
+                'Operation-Location': {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+      '/test4': {
+        post: {
+          responses: {
+            202: {
+              description: 'Accepted',
+              headers: {
+                'oPERATION-lOCATION': {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR fixes the `az-lro-headers` rule to check for `operation-location` case insensitively.  It also adds a new test to verify correct behavior.

Fixes #6