### PR TITLE
Add rule and test for request body not required

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -96,6 +96,10 @@ A requestBody/body parameter should only be specified for HTTP methods where
 the HTTP 1.1 specification [RFC7231][RFC7231] has explicitly defined semantics for request bodies.
 RFC7231 states that the payload for both get and delete "has no defined semantics".
 
+### az-request-body-optional
+
+Flag a body parameter/request body that is not marked as required. This is a common oversight.
+
 ### az-schema-description-or-title
 
 All schemas should have a description or title.

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -202,6 +202,17 @@ rules:
       functionOptions:
         notMatch: '/^body$/'
 
+  az-request-body-optional:
+    description: Flag optional request body -- common oversight.
+    message: The body parameter is not marked as required.
+    severity: hint
+    formats: ['oas2']
+    given:
+    - $.paths[*].[put,post,patch].parameters.[?(@.in == 'body')]
+    then:
+      field: required
+      function: truthy
+
   az-schema-description-or-title:
     description: All schemas should have a description or title.
     message: Schema should have a description or title.

--- a/test/request-body-optional.test.js
+++ b/test/request-body-optional.test.js
@@ -1,0 +1,102 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-request-body-optional');
+  return linter;
+});
+
+test('az-request-body-optional should find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        put: {
+          parameters: [
+            {
+              name: 'body',
+              in: 'body',
+              type: 'string',
+            },
+          ],
+        },
+      },
+      '/test2': {
+        patch: {
+          parameters: [
+            {
+              name: 'body',
+              in: 'body',
+              type: 'string',
+            },
+          ],
+        },
+      },
+      '/test3': {
+        post: {
+          parameters: [
+            {
+              name: 'body',
+              in: 'body',
+              type: 'string',
+            },
+          ],
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(3);
+    expect(results[0].path.join('.')).toBe('paths./test1.put.parameters.0');
+    expect(results[1].path.join('.')).toBe('paths./test2.patch.parameters.0');
+    expect(results[2].path.join('.')).toBe('paths./test3.post.parameters.0');
+  });
+});
+
+test('az-request-body-optional should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        put: {
+          parameters: [
+            {
+              name: 'body',
+              in: 'body',
+              type: 'string',
+              required: true,
+            },
+          ],
+        },
+      },
+      '/test2': {
+        patch: {
+          parameters: [
+            {
+              name: 'body',
+              in: 'body',
+              type: 'string',
+              required: true,
+            },
+          ],
+        },
+      },
+      '/test3': {
+        post: {
+          parameters: [
+            {
+              name: 'body',
+              in: 'body',
+              type: 'string',
+              required: true,
+            },
+          ],
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR adds a check for a put, patch, or post request body (body parameter in oas2) that is not marked as required.  This is not necessarily wrong but very unusual and a common oversight.  Tests included.