### PR TITLE
Add az-ms-paths rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -37,6 +37,9 @@ A 202 response should include an Operation-Location response header.
 
 Don't use the Autorest `x-ms-paths` extension except where necessary to support legacy APIs.
 
+`x-ms-paths` is needed to describe non-pure REST APIs that implement multiple operations on a single path and method,
+typically distinguished by a query parameter value, which is not supported by OpenAPI.
+
 ### az-operation-id
 
 The `operationId` should be of the form `Noun_Verb`.  It should contain exactly one underscore.

--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -33,6 +33,10 @@ All `4xx` and `5xx` responses should specify `x-ms-error-response: true` except 
 
 A 202 response should include an Operation-Location response header.
 
+### az-ms-paths
+
+Don't use the Autorest `x-ms-paths` extension except where necessary to support legacy APIs.
+
 ### az-operation-id
 
 The `operationId` should be of the form `Noun_Verb`.  It should contain exactly one underscore.

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -72,6 +72,14 @@ rules:
       functionOptions:
         name: Operation-location
 
+  az-ms-paths:
+    description: Don't use x-ms-paths except where necessary to support legacy APIs.
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given: $.x-ms-paths
+    then:
+      function: falsy
+
   az-operation-id:
     description: OperationId should conform to Azure API Guidelines
     message: '{{error}}'


### PR DESCRIPTION
A tiny PR to add a simple rule to check for the use of the `x-ms-paths` autorest extension in an API document. This extension is helpful for supporting legacy APIs that were designed prior to OpenAPI, but should otherwise be avoided if at all possible.