### PR TITLE
Add two new rules about additionalProperties

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -12,6 +12,20 @@ that can be used to disable rules for specific files or file globs and specific 
 
 ## Azure Custom Rules
 
+### az-additional-properties-and-properties
+
+Don't specify both `additionalProperties` and `properties` in the same object schema.
+Only use `additionalProperties` to define "map" structures.
+
+### az-additional-properties-object
+
+Specifying `additionalProperties` with `type: object` is usually an error.
+It specifies that the property value must be a JSON object, and not a string or number or array.
+What is probably intended is to allow property values of any type, which is best specified by simply omitting the `type`, e.g.:
+```json
+    "additionalProperties": {}
+```
+
 ### az-consistent-response-body
 
 For a path with a "create" operation (put or patch that returns 201), the 200 response of

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -25,6 +25,26 @@ rules:
   # Note: The Spectral VSCode extension will not display "hint" messages, so
   # use "info" rather than "hint".
 
+  az-additional-properties-and-properties:
+    description: Don't specify additionalProperties as a sibling of properties.
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given: $..[?(@.type === 'object' && @.properties)]
+    then:
+      field: additionalProperties
+      function: falsy
+
+  az-additional-properties-object:
+    description: additionalProperties with type object is a common error.
+    severity: info
+    formats: ['oas2', 'oas3']
+    given: $..[?(@.type === 'object')].additionalProperties
+    then:
+      field: type
+      function: pattern
+      functionOptions:
+        notMatch: '^object$'
+
   az-consistent-response-body:
     description: Ensure the get, put, and patch response body schemas are consistent.
     message: '{{error}}'


### PR DESCRIPTION
This PR adds two simple rules to check for common issues with `additionalProperties`.

The `az-additional-properties-and-properties` rule flags any schema that has _both_ `properties` and `additionalProperties`.  While this is valid in JSON schema it is difficult to represent this in high-level languages.

The `az-additional-properties-object` rule flags any instance of `additionalProperties` that specifies a schema as `type: object`.  A common misunderstanding is that this allows property values to be any valid JSON, but it does not -- strings, numbers, booleans, and arrays are all _invalid_.  This message is an "info" since it's possible that `type: object` is correct. 