### PR TITLE
Add az-header-disallowed rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -48,6 +48,21 @@ Every operation should have a default response with error response body.
 
 All `4xx` and `5xx` responses should specify `x-ms-error-response: true` except for `404` response of HEAD operation.
 
+### az-header-disallowed
+
+The `Authorization`, `Content-type`, and `Accept` headers should not be defined explicitly since their definition is
+implied by other elements of the API definition.
+
+In OpenAPI 2, valid values for `Authorization` should be specified in the `SecurityDefintions` / `Security` objects,
+values of `Content-type` are specified by `consumes`, and values of `Accept` are specified by `produces`.
+
+In OpenAPI 3, valid values for `Authorization` should be specified in the `SecuritySchemes` / `Security` objects,
+values of `Content-type` are specified by the keys of the `content` object in `requestBody`, and values of `Accept`
+are specified by union of the keys of the `content` objects of all elements of the `responses` object.
+
+The [OpenAPI 3 specification](https://github.com/OAI/OpenAPI-Specification/blob/3.0.3/versions/3.0.3.md#fixed-fields-10)
+explicitly states that these header definitions should be ignored.
+
 ### az-lro-headers
 
 A 202 response should include an Operation-Location response header.

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -81,6 +81,20 @@ rules:
     then:
       function: error-response
 
+  az-header-disallowed:
+    description: Authorization, Content-type, and Accept headers should not be defined explicitly.
+    message: 'Header parameter "{{value}}" should not defined explicitly.'
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given:
+    - $.paths[*].parameters.[?(@.in == 'header')]
+    - $.paths[*][get,put,post,patch,delete,options,head].parameters.[?(@.in == 'header')]
+    then:
+      function: pattern
+      field: name
+      functionOptions:
+        match: '^(authorization|content-type|accept)$/i'
+
   az-lro-headers:
     description: A 202 response should include an Operation-Location response header.
     message: A 202 response should include an Operation-Location response header.

--- a/test/header-disallowed.test.js
+++ b/test/header-disallowed.test.js
@@ -1,0 +1,83 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-header-disallowed');
+  return linter;
+});
+
+test('az-header-disallowed should find errors', () => {
+  // Test parameter names in 3 different places:
+  // 1. parameter at path level
+  // 2. inline parameter at operation level
+  // 3. referenced parameter at operation level
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        parameters: [
+          {
+            name: 'Authorization',
+            in: 'header',
+            type: 'string',
+          },
+        ],
+        get: {
+          parameters: [
+            {
+              name: 'Content-Type',
+              in: 'header',
+              type: 'string',
+            },
+            {
+              $ref: '#/parameters/AcceptParam',
+            },
+          ],
+        },
+      },
+    },
+    parameters: {
+      AcceptParam: {
+        name: 'Accept',
+        in: 'header',
+        type: 'string',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(3);
+    expect(results[0].path.join('.')).toBe('paths./test1.parameters.0.name');
+    expect(results[1].path.join('.')).toBe('paths./test1.get.parameters.0.name');
+    expect(results[2].path.join('.')).toBe('paths./test1.get.parameters.1.name');
+  });
+});
+
+test('az-header-disallowed should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        parameters: [
+          {
+            name: 'Authorization',
+            in: 'query',
+            type: 'string',
+          },
+        ],
+        get: {
+          parameters: [
+            {
+              name: 'Accept',
+              in: 'query',
+              type: 'string',
+            },
+          ],
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR adds a rule to flag header parameters `Authorization`, `Content-Type`, or `Accept`.  These parameters should not be defined explicitly since their definition is implied by other elements of the API definition.

The [OpenAPI 3 specification](https://github.com/OAI/OpenAPI-Specification/blob/3.0.3/versions/3.0.3.md#fixed-fields-10) explicitly states that these header definitions should be ignored.