### PR TITLE
Add az-formdata rule to suggest check on formData parameters

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -48,6 +48,14 @@ Every operation should have a default response with error response body.
 
 All `4xx` and `5xx` responses should specify `x-ms-error-response: true` except for `404` response of HEAD operation.
 
+### az-formdata
+
+Check for appropriate use of formData parameters.
+
+It can be appropriate to use formData parameters when sending multiple file-type parameters or an array of file-type parameters.
+But it is unnecessary and overly complicated to use formData to send a single file-type parameter.
+This should be defined as a `body` parameter with `type: string, format: binary` and use content-type `application/octet-stream`.
+
 ### az-header-disallowed
 
 The `Authorization`, `Content-type`, and `Accept` headers should not be defined explicitly since their definition is

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -81,6 +81,14 @@ rules:
     then:
       function: error-response
 
+  az-formdata:
+    description: Check for appropriate use of formData parameters.
+    severity: info
+    formats: ['oas2']
+    given: $.paths.*[get,put,post,patch,delete,options,head].parameters.[?(@.in == "formData")]
+    then:
+      function: falsy
+
   az-header-disallowed:
     description: Authorization, Content-type, and Accept headers should not be defined explicitly.
     message: 'Header parameter "{{value}}" should not defined explicitly.'


### PR DESCRIPTION
Another simple rule, level "info", to flag formData parameters to check for proper use.