### PR TITLE
Fix additional-properties-object rule

### DIFF
--- a/spectral.yaml
+++ b/spectral.yaml
@@ -38,12 +38,9 @@ rules:
     description: additionalProperties with type object is a common error.
     severity: info
     formats: ['oas2', 'oas3']
-    given: $..[?(@.type === 'object')].additionalProperties
+    given: $.[?(@property == 'additionalProperties' && @.type == 'object' && @.properties == undefined)]
     then:
-      field: type
-      function: pattern
-      functionOptions:
-        notMatch: '^object$'
+      function: falsy
 
   az-consistent-response-body:
     description: Ensure the get, put, and patch response body schemas are consistent.

--- a/test/additional-properties-object.test.js
+++ b/test/additional-properties-object.test.js
@@ -1,0 +1,73 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-additional-properties-object');
+  return linter;
+});
+
+test('az-additional-properties-object should find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    definitions: {
+      This: {
+        description: 'This',
+        type: 'object',
+        additionalProperties: {
+          type: 'object',
+        },
+      },
+      That: {
+        description: 'That',
+        type: 'object',
+        properties: {
+          params: {
+            additionalProperties: {
+              type: 'object',
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    expect(results[0].path.join('.')).toBe('definitions.This.additionalProperties');
+    expect(results[1].path.join('.')).toBe('definitions.That.properties.params.additionalProperties');
+  });
+});
+
+test('az-additional-properties-object should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    definitions: {
+      This: {
+        description: 'This',
+        type: 'object',
+        additionalProperties: {
+          type: 'string',
+          properties: {
+            prop1: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      That: {
+        description: 'That',
+        type: 'object',
+        properties: {
+          params: {
+            additionalProperties: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This is a small bug-fix PR for the az-additional-properties-object rule.  The prior code flagged cases where additional properties is an object with defined properties -- but that case is perfectly fine.  We only want to flag cases where additionalProperties is a simple object with no properties.

Sadly this rule does not currently work with Spectral v6+.  There is an issue open -- several people have reported similar problems.

https://github.com/stoplightio/spectral/issues/1920

Thankfully the VSCode extension is still using the v5.9 version and it works just fine.  I also added a test which seems to work fine.