### PR TITLE
Fix additional-properties-object rule in Spectral v6+

### DIFF
--- a/openapi-style-guide.md
+++ b/openapi-style-guide.md
@@ -122,7 +122,7 @@ All `4xx` and `5xx` responses should specify `x-ms-error-response: true` except 
 Every error response should include the `x-ms-error-code` response header in the `headers` of the response.
 
 Example:
-```
+```json
       "400": {
         "description": "Bad Request",
         "headers": {
@@ -143,7 +143,7 @@ Example:
 A 202 response should include the `Operation-Location` response header in the `headers` of the response.
 
 Example:
-```
+```json
     "responses": {
       "202": {
         "description": "The service has accepted the request and will start processing later.",

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -38,7 +38,7 @@ rules:
     description: additionalProperties with type object is a common error.
     severity: info
     formats: ['oas2', 'oas3']
-    given: $.[?(@property == 'additionalProperties' && @.type == 'object' && @.properties == undefined)]
+    given: $..[?(@property == 'additionalProperties' && @.type == 'object' && @.properties == undefined)]
     then:
       function: falsy
 

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -29,7 +29,7 @@ rules:
     description: Don't specify additionalProperties as a sibling of properties.
     severity: warn
     formats: ['oas2', 'oas3']
-    given: $..[?(@.type === 'object' && @.properties)]
+    given: $..[?(@object() && @.type === 'object' && @.properties)]
     then:
       field: additionalProperties
       function: falsy

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -38,6 +38,8 @@ rules:
     description: additionalProperties with type object is a common error.
     severity: info
     formats: ['oas2', 'oas3']
+    # This rule produces redundant errors if run on the resolved spec.
+    resolved: false
     given: $..[?(@property == 'additionalProperties' && @.type == 'object' && @.properties == undefined)]
     then:
       function: falsy

--- a/test/additional-properties-object.test.js
+++ b/test/additional-properties-object.test.js
@@ -46,7 +46,7 @@ test('az-additional-properties-object should find no errors', () => {
         description: 'This',
         type: 'object',
         additionalProperties: {
-          type: 'string',
+          type: 'object',
           properties: {
             prop1: {
               type: 'string',
@@ -62,6 +62,26 @@ test('az-additional-properties-object should find no errors', () => {
             additionalProperties: {
               type: 'string',
             },
+          },
+        },
+      },
+      ThaOther: {
+        description: 'ThaOther',
+        type: 'object',
+        properties: {
+          otherMap: {
+            additionalProperties: {
+              $ref: '#/definitions/Other',
+            },
+          },
+        },
+      },
+      Other: {
+        description: 'Other object',
+        type: 'object',
+        properties: {
+          aProp: {
+            type: 'string',
           },
         },
       },


### PR DESCRIPTION
This PR fixes the `az-additional-properties-object` rule when using Spectral v6+.

The JSON Path used in this rule had a subtle bug -- only looking at immediate children of root rather than recursing with "..".

Spectral v5.9 apparently mis-interpreted the single "." because it found occurrences that were not immediate children of root.  Spectral v6 fixed that, which exposed the bug in the rule.

With this fix, the rule works correctly in both Spectral v5.9 and Spectral v6+.

I also added some tests.

## Update!

I've pushed a few more small changes into this PR:
- The az-additional-properties-and-properties rule was causing a Spectral error if the API def contains a "null".  The fix is to check that the element is an object before inspecting its properties.
- The az-additional-properties-object rule was generating a message not just on the offending schema but also in any schema that $ref'ed it ... all the way up.  Restricting the rule to the raw spec fixes this.
- Minor doc fixes that were too small for their own PR.