### PR TITLE
Add az-security-definition-description rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -170,6 +170,10 @@ All schemas should have a description or title.
 
 Schema names should be Pascal case.
 
+### az-security-definition-description
+
+Security definition / security scheme should have a description.
+
 ### az-success-response-body
 
 All success responses except 202 and 204 should define a response body.

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -306,6 +306,18 @@ rules:
       functionOptions:
         type: pascal
 
+  az-security-definition-description:
+    description: A security definition should have a description.
+    message: Security definition should have a description.
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given: 
+    - $.securityDefinitions[*]
+    - $.components.securitySchemes[*]
+    then:
+      field: description
+      function: truthy
+
   # All success responses except 202 & 204 should define a response body
   # ref: https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#1321-put
   az-success-response-body:

--- a/test/security-definition-description.test.js
+++ b/test/security-definition-description.test.js
@@ -1,0 +1,80 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-security-definition-description');
+  return linter;
+});
+
+test('az-security-definition-description should find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    securityDefinitions: {
+      apim_key: {
+        type: 'apiKey',
+        name: 'Ocp-Apim-Subscription-Key',
+        in: 'header',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    expect(results[0].path.join('.')).toBe('securityDefinitions.apim_key');
+  });
+});
+
+test('az-security-definition-description should find oas3 errors', () => {
+  const oasDoc = {
+    openapi: '3.0.0',
+    components: {
+      securitySchemes: {
+        jwt: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    expect(results[0].path.join('.')).toBe('components.securitySchemes.jwt');
+  });
+});
+
+test('az-security-definition-description should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    securityDefinitions: {
+      apim_key: {
+        type: 'apiKey',
+        name: 'Ocp-Apim-Subscription-Key',
+        in: 'header',
+        description: 'API Key for your subscription',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});
+
+test('az-security-definition-description should find no oas3 errors', () => {
+  const oasDoc = {
+    openapi: '3.0.0',
+    components: {
+      securitySchemes: {
+        jwt: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'JSON Web Token with credentials for the service',
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR adds a simple rule to check that all security definitions / security schemes contain a description.

This rule should work for both oas2 and oas3 API definitions.

Tests included.