### PR TITLE
Drop check for default value in az-version-policy rule

### DIFF
--- a/functions/version-policy.js
+++ b/functions/version-policy.js
@@ -52,19 +52,12 @@ function findVersionParam(params) {
 
 // Verify version parameter has certain characteristics:
 // - it is required
-// - if it has a default value, it has the form YYYY-MM-DD
 function validateVersionParam(param, path) {
   const errors = [];
   if (!param.required) {
     errors.push({
       message: '"api-version" should be a required parameter',
       path,
-    });
-  }
-  if (param.default && !param.default.match(/^\d\d\d\d-\d\d-\d\d(-preview)?$/)) {
-    errors.push({
-      message: 'Default value for "api-version" should be a date in YYYY-MM-DD format, optionally suffixed with \'-preview\'.',
-      path: [...path, 'default'],
     });
   }
   return errors;

--- a/test/header-disallowed.test.js
+++ b/test/header-disallowed.test.js
@@ -83,8 +83,8 @@ test('az-header-disallowed should find no errors', () => {
               type: 'string',
             },
             {
-              $ref: '#/parameters/RequestIdParam'
-            }
+              $ref: '#/parameters/RequestIdParam',
+            },
           ],
         },
       },


### PR DESCRIPTION
This PR fixes the az-version-policy rule to drop the check on the `default` value for `api-version`.

Previously az-version-policy was checking the value of `default`, but this was inconsistent with the az-parameter-default-not-allowed rule that says required parameters should not have a default.

Tests are updated. 