### PR TITLE
Add Github action to test and lint

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test
+    - run: npm run lint

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ an API definition for conformance to the Azure API Guidelines and this Style Gui
 
 ## How to use the Spectral Ruleset
 
+### Dependencies
+
+The Spectral Ruleset requires Node version 14 or later.
+
 ### Install Spectral
 
 `npm install -g @stoplightio/spectral-cli`

--- a/package.json
+++ b/package.json
@@ -29,6 +29,11 @@
     "collectCoverage": true,
     "collectCoverageFrom": [
       "functions/*.js"
-    ]
+    ],
+    "coverageThreshold": {
+      "./functions/*.js": {
+        "statements": 80
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR adds a GitHub action to run test and lint on PRs to the main branch. I updated the jest config to require a minimum statement coverage of 80%.

I also discovered that some functions are using "optional chaining" which is not supported in Node 12, so I updated the README.md to say that Node 14+ is required.