### PR TITLE
Add az-param-order rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -124,9 +124,13 @@ All parameters should have a description.
 
 Path and query parameter names should be camel case (except `api-version`); header parameter names should be kebab case.
 
-### az-param-names-unique
+### az-parameter-names-unique
 
 All parameter names for an operation -- including parameters defined at the path level -- should be case-insensitive unique.
+
+### az-parameter-order
+
+Path parameters must be in the same order as in the path.
 
 ### az-patch-content-type
 

--- a/functions/param-order.js
+++ b/functions/param-order.js
@@ -1,0 +1,54 @@
+// Check conformance to Azure parameter order conventions:
+// - path parameters must be in the same order as the path
+
+// Note: Missing path parameters will be flagged by the Spectral path-params rule
+
+// `given` is the paths object
+module.exports = (paths) => {
+  if (paths === null || typeof paths !== 'object') {
+    return [];
+  }
+
+  const inPath = (p) => p.in === 'path';
+  const paramName = (p) => p.name;
+  const methods = ['get', 'post', 'put', 'patch', 'delete', 'options', 'head'];
+
+  const errors = [];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const pathKey of Object.keys(paths)) {
+    // find all the path parameters in pathKey
+    const paramsInPath = pathKey.match(/[^{}]+(?=})/g) ?? [];
+    if (paramsInPath.length > 0) {
+      const pathItem = paths[pathKey];
+      const pathItemPathParams = pathItem.parameters?.filter(inPath).map(paramName) ?? [];
+
+      const indx = pathItemPathParams.findIndex((v, i) => v !== paramsInPath[i]);
+      // path-params will flag cases where indx >= paramsInPath.length
+      if (indx >= 0 && indx < paramsInPath.length) {
+        // Note: we do not include `indx` in the path because if the parameter is a ref then
+        // Spectral will show the path of the ref'ed parameter and not the path/operation with
+        // improper ordering
+        errors.push({
+          message: `Path parameter "${paramsInPath[indx]}" should appear before "${pathItemPathParams[indx]}".`,
+          path: ['paths', pathKey, 'parameters'],
+        });
+      } else {
+        const offset = pathItemPathParams.length;
+        methods.filter((m) => pathItem[m]).forEach((method) => {
+          const opPathParams = pathItem[method].parameters?.filter(inPath).map(paramName) ?? [];
+
+          const indx2 = opPathParams.findIndex((v, i) => v !== paramsInPath[offset + i]);
+          if (indx2 >= 0 && (offset + indx2) < paramsInPath.length) {
+            errors.push({
+              message: `Path parameter "${paramsInPath[offset + indx2]}" should appear before "${opPathParams[indx2]}".`,
+              path: ['paths', pathKey, method, 'parameters'],
+            });
+          }
+        });
+      }
+    }
+  }
+
+  return errors;
+};

--- a/functions/param-order.js
+++ b/functions/param-order.js
@@ -1,7 +1,7 @@
 // Check conformance to Azure parameter order conventions:
 // - path parameters must be in the same order as the path
 
-// Note: Missing path parameters will be flagged by the Spectral path-params rule
+// NOTE: Missing path parameters will be flagged by the Spectral path-params rule
 
 // `given` is the paths object
 module.exports = (paths) => {
@@ -23,17 +23,19 @@ module.exports = (paths) => {
       const pathItem = paths[pathKey];
       const pathItemPathParams = pathItem.parameters?.filter(inPath).map(paramName) ?? [];
 
+      // find the first index where in-consistency observed or offset till no in-consistency
+      // observed to validate further
       const indx = pathItemPathParams.findIndex((v, i) => v !== paramsInPath[i]);
-      // path-params will flag cases where indx >= paramsInPath.length
+      // If path params exists and are not in expected order then raise the error
       if (indx >= 0 && indx < paramsInPath.length) {
-        // Note: we do not include `indx` in the path because if the parameter is a ref then
+        // NOTE: we do not include `indx` in the path because if the parameter is a ref then
         // Spectral will show the path of the ref'ed parameter and not the path/operation with
         // improper ordering
         errors.push({
           message: `Path parameter "${paramsInPath[indx]}" should appear before "${pathItemPathParams[indx]}".`,
-          path: ['paths', pathKey, 'parameters'],
+          path: ['paths', pathKey, 'parameters'], // no index in path
         });
-      } else {
+      } else { // this will be a case when few path params are defined in respective methods
         const offset = pathItemPathParams.length;
         methods.filter((m) => pathItem[m]).forEach((method) => {
           const opPathParams = pathItem[method].parameters?.filter(inPath).map(paramName) ?? [];
@@ -42,7 +44,7 @@ module.exports = (paths) => {
           if (indx2 >= 0 && (offset + indx2) < paramsInPath.length) {
             errors.push({
               message: `Path parameter "${paramsInPath[offset + indx2]}" should appear before "${opPathParams[indx2]}".`,
-              path: ['paths', pathKey, method, 'parameters'],
+              path: ['paths', pathKey, method, 'parameters'], // no index in path
             });
           }
         });

--- a/openapi-style-guide.md
+++ b/openapi-style-guide.md
@@ -164,6 +164,10 @@ Example:
 
 All parameter names for an operation -- including parameters defined at the path level -- should be case-insensitive unique.
 
+### Parameter order
+
+Path parameters should be in the same order as they appear in the path.
+
 ### Descriptions
 
 Every parameter should have a description.

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -9,6 +9,7 @@ functions:
   - pagination-response
   - param-names
   - param-names-unique
+  - param-order
   - patch-content-type
   - version-policy
 rules:
@@ -204,6 +205,15 @@ rules:
     given: $.paths[*]
     then:
       function: param-names-unique
+
+  az-parameter-order:
+    description: Path parameters must be in the same order as in the path.
+    message: '{{error}}'
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given: $.paths
+    then:
+      function: param-order
 
   # Patch request body content type should be application/merge-patch+json
   az-patch-content-type:

--- a/test/parameter-order.test.js
+++ b/test/parameter-order.test.js
@@ -1,0 +1,266 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-parameter-order');
+  return linter;
+});
+
+test('az-parameter-order should find errors', () => {
+  // Test parameter ordering at path item level and operation level.
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1/{p1}/foo/{p2}': {
+        parameters: [
+          {
+            name: 'p2',
+            in: 'path',
+            type: 'string',
+          },
+          {
+            name: 'p1',
+            in: 'path',
+            type: 'string',
+          },
+        ],
+        get: {
+          parameters: [
+            {
+              name: 'p3',
+              in: 'query',
+              type: 'string',
+            },
+          ],
+        },
+      },
+      '/test2/{p1}/foo/{p2}/bar/{p3}': {
+        parameters: [
+          {
+            name: 'p1',
+            in: 'path',
+            type: 'string',
+          },
+        ],
+        get: {
+          parameters: [
+            {
+              name: 'p3',
+              in: 'path',
+              type: 'string',
+            },
+            {
+              name: 'p2',
+              in: 'path',
+              type: 'string',
+            },
+          ],
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    expect(results[0].path.join('.')).toBe('paths./test1/{p1}/foo/{p2}.parameters.0');
+    expect(results[1].path.join('.')).toBe('paths./test2/{p1}/foo/{p2}/bar/{p3}.get.parameters.0');
+  });
+});
+
+test('az-parameter-order should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1/{p1}/foo/{p2}': {
+        parameters: [
+          {
+            name: 'p1',
+            in: 'path',
+            type: 'string',
+          },
+          {
+            name: 'p2',
+            in: 'path',
+            type: 'string',
+          },
+        ],
+        get: {
+          parameters: [
+            {
+              name: 'p3',
+              in: 'query',
+              type: 'string',
+            },
+          ],
+        },
+      },
+      '/test2/{p1}/foo/{p2}/bar/{p3}': {
+        parameters: [
+          {
+            name: 'p1',
+            in: 'path',
+            type: 'string',
+          },
+        ],
+        get: {
+          parameters: [
+            {
+              name: 'p2',
+              in: 'path',
+              type: 'string',
+            },
+            {
+              name: 'p3',
+              in: 'path',
+              type: 'string',
+            },
+          ],
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});
+
+test('az-parameter-order should find oas3 errors', () => {
+  // Test parameter ordering at path item level and operation level.
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1/{p1}/foo/{p2}': {
+        parameters: [
+          {
+            name: 'p2',
+            in: 'path',
+            schema: {
+              type: 'string',
+            },
+          },
+          {
+            name: 'p1',
+            in: 'path',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        get: {
+          parameters: [
+            {
+              name: 'p3',
+              in: 'query',
+              schema: {
+                type: 'string',
+              },
+            },
+          ],
+        },
+      },
+      '/test2/{p1}/foo/{p2}/bar/{p3}': {
+        parameters: [
+          {
+            name: 'p1',
+            in: 'path',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        get: {
+          parameters: [
+            {
+              name: 'p3',
+              in: 'path',
+              schema: {
+                type: 'string',
+              },
+            },
+            {
+              name: 'p2',
+              in: 'path',
+              schema: {
+                type: 'string',
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    expect(results[0].path.join('.')).toBe('paths./test1/{p1}/foo/{p2}.parameters.0');
+    expect(results[1].path.join('.')).toBe('paths./test2/{p1}/foo/{p2}/bar/{p3}.get.parameters.0');
+  });
+});
+
+test('az-parameter-order should find no oas3 errors', () => {
+  const oasDoc = {
+    openapi: '3.0.3',
+    paths: {
+      '/test1/{p1}/foo/{p2}': {
+        parameters: [
+          {
+            name: 'p1',
+            in: 'path',
+            schema: {
+              type: 'string',
+            },
+          },
+          {
+            name: 'p2',
+            in: 'path',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        get: {
+          parameters: [
+            {
+              name: 'p3',
+              in: 'query',
+              schema: {
+                type: 'string',
+              },
+            },
+          ],
+        },
+      },
+      '/test2/{p1}/foo/{p2}/bar/{p3}': {
+        parameters: [
+          {
+            name: 'p1',
+            in: 'path',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        get: {
+          parameters: [
+            {
+              name: 'p2',
+              in: 'path',
+              schema: {
+                type: 'string',
+              },
+            },
+            {
+              name: 'p3',
+              in: 'path',
+              schema: {
+                type: 'string',
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/parameter-order.test.js
+++ b/test/parameter-order.test.js
@@ -62,8 +62,8 @@ test('az-parameter-order should find errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
-    expect(results[0].path.join('.')).toBe('paths./test1/{p1}/foo/{p2}.parameters.0');
-    expect(results[1].path.join('.')).toBe('paths./test2/{p1}/foo/{p2}/bar/{p3}.get.parameters.0');
+    expect(results[0].path.join('.')).toBe('paths./test1/{p1}/foo/{p2}.parameters');
+    expect(results[1].path.join('.')).toBe('paths./test2/{p1}/foo/{p2}/bar/{p3}.get.parameters');
   });
 });
 
@@ -191,8 +191,8 @@ test('az-parameter-order should find oas3 errors', () => {
   };
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
-    expect(results[0].path.join('.')).toBe('paths./test1/{p1}/foo/{p2}.parameters.0');
-    expect(results[1].path.join('.')).toBe('paths./test2/{p1}/foo/{p2}/bar/{p3}.get.parameters.0');
+    expect(results[0].path.join('.')).toBe('paths./test1/{p1}/foo/{p2}.parameters');
+    expect(results[1].path.join('.')).toBe('paths./test2/{p1}/foo/{p2}/bar/{p3}.get.parameters');
   });
 });
 


### PR DESCRIPTION
This PR adds a rule to check that the order of path parameters in the parameter list (both at the path-item and operation level) is consistent with the order of path parameters in the path template.

For example, all the operations for path:
```
    "paths": {
        "/foo/{p1}/bar/{p2}/baz/{p3}": {
```

should have `p1` before `p2` before `p3` in its parameter list.

This ordering helps make generated methods for these operations more natural and provides consistency across services.

Fixes #19