### PR TITLE
Add az-lro-extension rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -71,6 +71,10 @@ are specified by union of the keys of the `content` objects of all elements of t
 The [OpenAPI 3 specification](https://github.com/OAI/OpenAPI-Specification/blob/3.0.3/versions/3.0.3.md#fixed-fields-10)
 explicitly states that these header definitions should be ignored.
 
+### az-lro-extension
+
+Operations with a 202 response should specify `x-ms-long-running-operation: true`.
+
 ### az-lro-headers
 
 A 202 response should include an Operation-Location response header.

--- a/docs/crossref.md
+++ b/docs/crossref.md
@@ -15,7 +15,7 @@
 | [NonApplicationJsonType][r2004] | R2004 | |
 | [LongRunningResponseStatusCode][r2005] | R2005 | Add |
 | [ControlCharactersNotAllowed][r2006] | R2006 |  |
-| [LongRunningOperationsWithLongRunningExtension][r2007] | R2007 | Add |
+| [LongRunningOperationsWithLongRunningExtension][r2007] | R2007 | [az-lro-extension](./azure-ruleset.md#az-lro-extension) |
 | [MutabilityWithReadOnlyRule][r2008] | R2008 |  |
 | [ArraySchemaMustHaveItems][r2009] | R2009 | Add |
 | [LongRunningOperationsOptionsValidator][r2010] | R2010 | Add ? |

--- a/openapi-style-guide.md
+++ b/openapi-style-guide.md
@@ -113,6 +113,11 @@ To support pagination:
 - If the operation has a `top` parameter, it must be an integer, optional, and have a documented default and maximum value
 - If the operation has a `maxpagesize` parameter, it must be an integer, optional, and have a documented default and maximum value
 
+### Long-running operations
+
+All long-running operations should specify the autorest extension `x-ms-long-running-operation: true`.
+This informs the client library generators to include support for checking operation completion.
+
 ### Error response
 
 All operations should have a "default" (error) response with a response body that conforms to the Azure API Guidelines.

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -103,6 +103,16 @@ rules:
       functionOptions:
         notMatch: '/^(authorization|content-type|accept)$/i'
 
+  az-lro-extension:
+    description: "Operations with a 202 response should specify `x-ms-long-running-operation: true`."
+    message: "Operations with a 202 response should specify `x-ms-long-running-operation: true`."
+    severity: warn
+    formats: ['oas2']
+    given: $.paths[*][*].responses[?(@property == '202')]^^
+    then:
+      field: x-ms-long-running-operation
+      function: truthy
+
   az-lro-headers:
     description: A 202 response should include an Operation-Location response header.
     message: A 202 response should include an Operation-Location response header.


### PR DESCRIPTION
This PR adds a simple rule (yaml only) to check that an operation that returns a 202 response is marked with `x-ms-long-running-operation: true`.