### PR TITLE
Fix test setup and re-enable property-description tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -780,6 +780,18 @@
         "chalk": "^4.0.0"
       }
     },
+    "@jsep-plugin/regex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.1.tgz",
+      "integrity": "sha512-GroTtexnEfdVOvvALjW/JfV+wgRMadZKEA/lf9gE09zJejHhcBl+cqJxk2px9ub8k3gUrPe1j81Z1V4RDaSy8A==",
+      "dev": true
+    },
+    "@jsep-plugin/ternary": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/ternary/-/ternary-1.0.2.tgz",
+      "integrity": "sha512-hoCxJW/uVT1z9LGsZr1t2m7XNmE5k8w2P+5hfegVOuy9bQFrFESRe/XSd+KZ4eAbGnTkyHqOPct2LTa9qFUrMQ==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -799,38 +811,26 @@
       }
     },
     "@stoplight/better-ajv-errors": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-0.2.0.tgz",
-      "integrity": "sha512-3vBbXBDplfeOGS2rT4PyOwJ1K0A7/NqlVXI6sJ/XchQlrMXFMKtj4qExBLxr4M9ZiiESu48uhbdS3Nx8A0S+ZA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-1.0.1.tgz",
+      "integrity": "sha512-rgxT+ZMeZbYRiOLNk6Oy6e/Ig1iQKo0IL8v/Y9E/0FewzgtkGs/p5dMeUpIFZXWj3RZaEPmfL9yh0oUEmNXZjg==",
       "dev": true,
       "requires": {
-        "jsonpointer": "^4.0.1",
+        "jsonpointer": "^5.0.0",
         "leven": "^3.1.0"
       }
     },
     "@stoplight/json": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.15.0.tgz",
-      "integrity": "sha512-FxdmBaZyt6FZVN8F/GaGzevLxjkW1gLHC5cPeb4slMM8BIXCxKluIkGLzmb4bnkk2+4gPaYj75V28U6s0WNrbQ==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.17.1.tgz",
+      "integrity": "sha512-OQbjaPU9/VPQYa3zEfN82vjXu3vWv/537Ei7TX/xYLMPdpdBI/mCyThdZAG4SN1t3iho2dxIKpTVObuCTTgBvA==",
       "dev": true,
       "requires": {
-        "@stoplight/ordered-object-literal": "^1.0.1",
-        "@stoplight/types": "^12.2.0",
+        "@stoplight/ordered-object-literal": "^1.0.2",
+        "@stoplight/types": "^12.3.0",
         "jsonc-parser": "~2.2.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "safe-stable-stringify": "^1.1"
-      },
-      "dependencies": {
-        "@stoplight/types": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-12.3.0.tgz",
-          "integrity": "sha512-hgzUR1z5BlYvIzUeFK5pjs5JXSvEutA9Pww31+dVicBlunsG1iXopDx/cvfBY7rHOrgtZDuvyeK4seqkwAZ6Cg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "utility-types": "^3.10.0"
-          }
-        }
       }
     },
     "@stoplight/json-ref-readers": {
@@ -868,21 +868,6 @@
         "lodash.set": "^4.3.2",
         "tslib": "^2.3.1",
         "urijs": "^1.19.6"
-      },
-      "dependencies": {
-        "@stoplight/json": {
-          "version": "3.17.0",
-          "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.17.0.tgz",
-          "integrity": "sha512-WW0z2bb0D4t8FTl+zNTCu46J8lEOsrUhBPgwEYQ3Ri2Y0MiRE4U1/9ZV8Ki+pIJznZgY9i42bbFwOBxyZn5/6w==",
-          "dev": true,
-          "requires": {
-            "@stoplight/ordered-object-literal": "^1.0.2",
-            "@stoplight/types": "^12.3.0",
-            "jsonc-parser": "~2.2.1",
-            "lodash": "^4.17.21",
-            "safe-stable-stringify": "^1.1"
-          }
-        }
       }
     },
     "@stoplight/lifecycle": {
@@ -907,75 +892,77 @@
       "dev": true
     },
     "@stoplight/spectral-core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.4.0.tgz",
-      "integrity": "sha512-8f+ciIC4gsBLu3pbedz9nsk1ZJQvhj60iHo+893itpCfKovJ8+/IxVHpC6nJyhFuhJByiQsdpTEQjkjs5vaVdg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.8.1.tgz",
+      "integrity": "sha512-HYrQZhJ8H/ZWpnWL+E1kez4ezQOVaNlZCeUTSsS8ul597wDSLp4xFO9vat9cpY+oJUoAL/vgwJN4iwwxiDClLQ==",
       "dev": true,
       "requires": {
-        "@stoplight/better-ajv-errors": "0.2.0",
-        "@stoplight/json": "3.15.0",
+        "@stoplight/better-ajv-errors": "1.0.1",
+        "@stoplight/json": "~3.17.1",
         "@stoplight/lifecycle": "2.3.2",
         "@stoplight/path": "1.3.2",
         "@stoplight/spectral-parsers": "^1.0.0",
         "@stoplight/spectral-ref-resolver": "^1.0.0",
         "@stoplight/spectral-runtime": "^1.0.0",
         "@stoplight/types": "12.3.0",
-        "ajv": "~8.6.0",
+        "ajv": "^8.6.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
         "blueimp-md5": "2.18.0",
-        "expression-eval": "4.0.0",
-        "json-schema": "0.3.0",
-        "jsonpath-plus": "5.0.7",
+        "json-schema": "0.4.0",
+        "jsonpath-plus": "6.0.1",
         "lodash": "~4.17.21",
+        "lodash.topath": "^4.5.2",
         "minimatch": "3.0.4",
-        "nimma": "0.0.0",
-        "tslib": "~2.3.0"
+        "nimma": "0.1.7",
+        "simple-eval": "1.0.0",
+        "tslib": "^2.3.0"
       }
     },
     "@stoplight/spectral-formats": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.0.1.tgz",
-      "integrity": "sha512-l4cZ6imTqdCmNI8eexvWMoSSptx2lmdFRXSiX7P9ZDdKeRjQkJ49U5OttRr69IBaWdiHEP8Gw/cfnZDYOJKD5A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.0.2.tgz",
+      "integrity": "sha512-jMIlMTSCJzFKq3kXnHv+YC0TTnwli/DuZY4JxObyaBwdiG1LnSAJLL7R857PpJpQ1uoiZULov8clxudSMeKL+Q==",
       "dev": true,
       "requires": {
-        "@stoplight/json": "3.15.0",
-        "@stoplight/spectral-core": "^1.1.0",
-        "@stoplight/types": "12.3.0",
-        "@types/json-schema": "^7.0.7"
-      },
-      "dependencies": {
-        "@stoplight/types": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-12.3.0.tgz",
-          "integrity": "sha512-hgzUR1z5BlYvIzUeFK5pjs5JXSvEutA9Pww31+dVicBlunsG1iXopDx/cvfBY7rHOrgtZDuvyeK4seqkwAZ6Cg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "utility-types": "^3.10.0"
-          }
-        }
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/spectral-core": "^1.8.0",
+        "@types/json-schema": "^7.0.7",
+        "tslib": "^2.3.1"
       }
     },
     "@stoplight/spectral-functions": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.2.1.tgz",
-      "integrity": "sha512-3RiL18a2SqXe7bGbVnVywgZjEHUrS1fKXEoOTwc76ixusqRjGeYq76JlB06S6fGXeGfr1ylcmHwAkwXTCns3aQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.5.1.tgz",
+      "integrity": "sha512-KHMprX4OwjgVtzUulVPfqkZTNCAP4JbZqTQ5/UTCfrQ1nO4vcr+3CJgU74ggSP6rH3UuJIIFVZN+9wU7HP1bEA==",
       "dev": true,
       "requires": {
-        "@stoplight/better-ajv-errors": "0.2.0",
-        "@stoplight/json": "3.15.0",
-        "@stoplight/spectral-core": "^1.1.0",
+        "@stoplight/better-ajv-errors": "1.0.1",
+        "@stoplight/json": "~3.17.1",
+        "@stoplight/spectral-core": "^1.7.0",
         "@stoplight/spectral-formats": "^1.0.0",
-        "@stoplight/spectral-runtime": "*",
+        "@stoplight/spectral-runtime": "^1.1.0",
         "@stoplight/types": "12.3.0",
-        "ajv": "~8.6.0",
+        "ajv": "^8.6.3",
+        "ajv-draft-04": "~1.0.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
-        "json-schema-migrate": "~2.0.0",
-        "json-schema-traverse": "~1.0.0",
         "lodash": "~4.17.21",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        }
       }
     },
     "@stoplight/spectral-parsers": {
@@ -1019,48 +1006,38 @@
       }
     },
     "@stoplight/spectral-ruleset-migrator": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.4.2.tgz",
-      "integrity": "sha512-egW1wbYVBUdtozHiqDYtDXrSBmU4ep3/kLQ46Il7KmDxzQFDTcn7UfXiiUjEhBlrc56fZymSE3HEQdaUKYqypA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.7.1.tgz",
+      "integrity": "sha512-FEbHjpIaIwwWR/fTvEl4EPMgZvcI2L6G4JBMj+fW/aP7shEXaKpeXNrI67W+MDFAYiInJtwlytYuL67euyfAWw==",
       "dev": true,
       "requires": {
-        "@stoplight/json": "3.15.0",
-        "@stoplight/ordered-object-literal": "^1.0.2",
+        "@stoplight/json": "~3.17.0",
+        "@stoplight/ordered-object-literal": "1.0.2",
         "@stoplight/path": "1.3.2",
         "@stoplight/spectral-functions": "^1.0.0",
-        "@stoplight/spectral-runtime": "*",
-        "@stoplight/types": "12.3.0",
+        "@stoplight/spectral-runtime": "^1.1.0",
+        "@stoplight/types": "^12.3.0",
         "@stoplight/yaml": "4.2.2",
         "@types/node": "*",
         "ajv": "^8.6.0",
         "ast-types": "0.14.2",
         "astring": "^1.7.5",
-        "reserved": "0.1.2"
-      },
-      "dependencies": {
-        "@stoplight/types": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-12.3.0.tgz",
-          "integrity": "sha512-hgzUR1z5BlYvIzUeFK5pjs5JXSvEutA9Pww31+dVicBlunsG1iXopDx/cvfBY7rHOrgtZDuvyeK4seqkwAZ6Cg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "utility-types": "^3.10.0"
-          }
-        }
+        "reserved": "0.1.2",
+        "tslib": "^2.3.1"
       }
     },
     "@stoplight/spectral-rulesets": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.2.4.tgz",
-      "integrity": "sha512-m5zODWb2g+I26GmLnClvMOBP0KSC+uVr4AiUzSrd/ianMcd+cSxtUu4cDl+syJQjr8fwjnzibuxQWh+WLjuVcw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.3.1.tgz",
+      "integrity": "sha512-twcJ4HhAsOs7FO1elI40zU/u1bPfCVcnsbMPU+syaGzCncSBGN8ZDM0OZ5WekfaL+/AN0rTIzmmEcvMsh42JqQ==",
       "dev": true,
       "requires": {
-        "@stoplight/better-ajv-errors": "0.2.0",
-        "@stoplight/json": "3.15.0",
+        "@stoplight/better-ajv-errors": "1.0.1",
+        "@stoplight/json": "3.17.0",
         "@stoplight/spectral-core": "^1.3.0",
         "@stoplight/spectral-formats": "^1.0.1",
         "@stoplight/spectral-functions": "^1.1.2",
+        "@stoplight/spectral-runtime": "^1.0.0",
         "@stoplight/types": "^12.3.0",
         "@types/json-schema": "^7.0.7",
         "ajv": "~8.6.0",
@@ -1070,42 +1047,34 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
-        "@stoplight/types": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-12.3.0.tgz",
-          "integrity": "sha512-hgzUR1z5BlYvIzUeFK5pjs5JXSvEutA9Pww31+dVicBlunsG1iXopDx/cvfBY7rHOrgtZDuvyeK4seqkwAZ6Cg==",
+        "@stoplight/json": {
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.17.0.tgz",
+          "integrity": "sha512-WW0z2bb0D4t8FTl+zNTCu46J8lEOsrUhBPgwEYQ3Ri2Y0MiRE4U1/9ZV8Ki+pIJznZgY9i42bbFwOBxyZn5/6w==",
           "dev": true,
           "requires": {
-            "@types/json-schema": "^7.0.4",
-            "utility-types": "^3.10.0"
+            "@stoplight/ordered-object-literal": "^1.0.2",
+            "@stoplight/types": "^12.3.0",
+            "jsonc-parser": "~2.2.1",
+            "lodash": "^4.17.21",
+            "safe-stable-stringify": "^1.1"
           }
         }
       }
     },
     "@stoplight/spectral-runtime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-runtime/-/spectral-runtime-1.1.0.tgz",
-      "integrity": "sha512-/9gjGFRNf+h8iJ5OOUASMI+SNNovVcjcRzdiCMzOMQGnhc9GR77rqL7U7E5zoJymuwIXkvvvPt1Ka0QiSH/5zA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-runtime/-/spectral-runtime-1.1.1.tgz",
+      "integrity": "sha512-sOradfNLO6wOjCasMEM9fm5hykZe2E4gqAY1WCcGueDoq4VlDFbTb7X4aO5jKbFqF+V+ctWlaXTftlhElG9pcQ==",
       "dev": true,
       "requires": {
-        "@stoplight/json": "^3.15.0",
+        "@stoplight/json": "^3.17.0",
         "@stoplight/path": "^1.3.2",
         "@stoplight/types": "^12.3.0",
         "abort-controller": "^3.0.0",
         "lodash": "^4.17.21",
-        "node-fetch": "^2.6.1"
-      },
-      "dependencies": {
-        "@stoplight/types": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-12.3.0.tgz",
-          "integrity": "sha512-hgzUR1z5BlYvIzUeFK5pjs5JXSvEutA9Pww31+dVicBlunsG1iXopDx/cvfBY7rHOrgtZDuvyeK4seqkwAZ6Cg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "utility-types": "^3.10.0"
-          }
-        }
+        "node-fetch": "^2.6.1",
+        "tslib": "^2.3.1"
       }
     },
     "@stoplight/types": {
@@ -1128,18 +1097,6 @@
         "@stoplight/types": "^12.0.0",
         "@stoplight/yaml-ast-parser": "0.0.48",
         "tslib": "^2.2.0"
-      },
-      "dependencies": {
-        "@stoplight/types": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-12.3.0.tgz",
-          "integrity": "sha512-hgzUR1z5BlYvIzUeFK5pjs5JXSvEutA9Pww31+dVicBlunsG1iXopDx/cvfBY7rHOrgtZDuvyeK4seqkwAZ6Cg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "utility-types": "^3.10.0"
-          }
-        }
       }
     },
     "@stoplight/yaml-ast-parser": {
@@ -1343,6 +1300,12 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true
+    },
     "ajv-errors": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
@@ -1470,9 +1433,9 @@
       "dev": true
     },
     "astring": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.7.5.tgz",
-      "integrity": "sha512-lobf6RWXb8c4uZ7Mdq0U12efYmpD1UFnyOWVJPTa3ukqZrMopav+2hdNu0hgBF0JIBFK9QgrBDfwYvh3DFJDAA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.1.tgz",
+      "integrity": "sha512-Aj3mbwVzj7Vve4I/v2JYOPFkCGM2YS7OqQTNSxmUR+LECRpokuPgAYghePgr6SALDo5bD5DlfbSaYjOzGJZOLQ==",
       "dev": true
     },
     "asynckit": {
@@ -2483,15 +2446,6 @@
         }
       }
     },
-    "expression-eval": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/expression-eval/-/expression-eval-4.0.0.tgz",
-      "integrity": "sha512-YHSnLTyIb9IKaho2IdQbvlei/pElxnGm48UgaXJ1Fe5au95Ck0R9ftm6rHJQuKw3FguZZ4eXVllJFFFc7LX0WQ==",
-      "dev": true,
-      "requires": {
-        "jsep": "^0.3.0"
-      }
-    },
     "extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -2817,9 +2771,9 @@
       "dev": true
     },
     "immer": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
-      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.7.tgz",
+      "integrity": "sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA==",
       "dev": true
     },
     "import-fresh": {
@@ -3830,9 +3784,9 @@
       }
     },
     "jsep": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.5.tgz",
-      "integrity": "sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.2.0.tgz",
+      "integrity": "sha512-ex4YB352GD74qLjjAtjYm33LcHDBAwhY01BgZbXU56eLWOM1JvKYX4lz4PYkqw0OVfAQYl7CRt0JBRuAUt7mqA==",
       "dev": true
     },
     "jsesc": {
@@ -3848,19 +3802,10 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
-      "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
-    },
-    "json-schema-migrate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
-      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
-      "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      }
     },
     "json-schema-traverse": {
       "version": "1.0.0",
@@ -3890,15 +3835,15 @@
       "dev": true
     },
     "jsonpath-plus": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-5.0.7.tgz",
-      "integrity": "sha512-7TS6wsiw1s2UMK/A6nA4n0aUJuirCVhJ87nWX5je5MPOl0z5VTr2qs7nMP8NZ2ed3rlt6kePTqddgVPE9F0i0w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
+      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
       "dev": true
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
     },
     "kind-of": {
@@ -4039,6 +3984,12 @@
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "lodash.topath": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
+      "integrity": "sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=",
+      "dev": true
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -4190,20 +4141,51 @@
       "dev": true
     },
     "nimma": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.0.0.tgz",
-      "integrity": "sha512-if0VqyHpTMHKFORMiJ2WLWgoIF4xqwjybHZyvodQ/yCmiWag6RhLlMHeFukz4X31DanTBA26U+HwvXIrTaYQkQ==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.1.7.tgz",
+      "integrity": "sha512-0FIra4ogMHhOjn4fd2UiBuuaxM1nHzwhCEPvaFmCbwsR6qzHyJUG3dLW3tAIQji42wIij8OA/HB0+Gldg3OX4A==",
       "dev": true,
       "requires": {
-        "astring": "^1.4.3",
-        "jsep": "^0.3.4"
+        "@jsep-plugin/regex": "^1.0.1",
+        "@jsep-plugin/ternary": "^1.0.2",
+        "astring": "^1.8.1",
+        "jsep": "^1.2.0",
+        "jsonpath-plus": "^6.0.1",
+        "lodash.topath": "^4.5.2"
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -4932,6 +4914,15 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "simple-eval": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.0.tgz",
+      "integrity": "sha512-kpKJR+bqTscgC0xuAl2xHN6bB12lHjC2DCUfqjAx19bQyO3R2EVLOurm3H9AUltv/uFVcSCVNc6faegR+8NYLw==",
+      "dev": true,
+      "requires": {
+        "jsep": "^1.1.2"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "url": "https://github.com/Azure/azure-api-style-guide"
   },
   "devDependencies": {
-    "@stoplight/spectral-core": "1.4.0",
-    "@stoplight/spectral-ruleset-migrator": "^1.4.2",
-    "@stoplight/spectral-rulesets": "^1.2.4",
+    "@stoplight/spectral-core": "1.8.1",
+    "@stoplight/spectral-ruleset-migrator": "^1.7.1",
+    "@stoplight/spectral-rulesets": "^1.3.1",
     "ajv": "^8.6.2",
     "eslint": "^7.30.0",
     "eslint-config-airbnb-base": "^14.2.1",
@@ -34,6 +34,11 @@
       "./functions/*.js": {
         "statements": 80
       }
+    },
+    "moduleNameMapper": {
+      "^nimma/legacy$": "<rootDir>/node_modules/nimma/dist/legacy/cjs/index.js",
+      "^nimma/(.*)": "<rootDir>/node_modules/nimma/dist/cjs/$1",
+      "^@stoplight/spectral-ruleset-bundler/(.*)$": "<rootDir>/node_modules/@stoplight/spectral-ruleset-bundler/dist/$1"
     }
   }
 }

--- a/test/property-description.test.js
+++ b/test/property-description.test.js
@@ -13,7 +13,7 @@ beforeAll(async () => {
 // - top-level schema in definitions
 // - inner schema in definitions
 
-test.skip('az-property-description should find errors', () => {
+test('az-property-description should find errors', () => {
   const oasDoc = {
     swagger: '2.0',
     paths: {
@@ -104,7 +104,7 @@ test.skip('az-property-description should find errors', () => {
   });
 });
 
-test.skip('az-property-description should find no errors', () => {
+test('az-property-description should find no errors', () => {
   const oasDoc = {
     swagger: '2.0',
     paths: {


### PR DESCRIPTION
After much trial and error I discovered the magic needed to be able to run the `az-property-description` tests successfully.

As a bonus, updating the spectral packages has resolved all the outstanding npm audit issues.

Fixes #47