### PR TITLE
Add az-path-parameter-schema rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -146,6 +146,11 @@ Only patch operations should accept JSON merge patch.
 
 Service-defined path segments should be restricted to 0-9 A-Z a-z - . _ ~, with : allowed only as described below to designate an action operation.
 
+### az-path-parameter-schema
+
+Path parameters should be defined as `type: string` with a `maxLength` and a `pattern` that restricts
+the characters that can be be used in the parameter value.
+
 ### az-post-201-response
 
 Using post for a create operation is discouraged.  Use put or patch instead.

--- a/functions/path-param-schema.js
+++ b/functions/path-param-schema.js
@@ -1,0 +1,49 @@
+// `given` is a (resolved) parameter entry at the path or operation level
+module.exports = (param, _opts, paths) => {
+  if (param === null || typeof param !== 'object') {
+    return [];
+  }
+
+  const path = paths.path || paths.target || [];
+
+  // These errors will be caught elsewhere, so silently ignore here
+  if (!param.in || !param.name) {
+    return [];
+  }
+
+  const errors = [];
+
+  // If the parameter contains a schema, then this must be oas3
+  const isOas3 = !!param.schema;
+
+  const schema = isOas3 ? param.schema : param;
+  if (isOas3) {
+    path.push('schema');
+  }
+
+  if (schema.type !== 'string') {
+    errors.push({
+      message: 'Path parameter should be defined as type: string.',
+      path: [...path, 'type'],
+    });
+  }
+
+  if (!schema.maxLength && !schema.pattern) {
+    errors.push({
+      message: 'Path parameter should specify a maximum length (maxLength) and characters allowed (pattern).',
+      path,
+    });
+  } else if (!schema.maxLength) {
+    errors.push({
+      message: 'Path parameter should specify a maximum length (maxLength).',
+      path,
+    });
+  } else if (!schema.pattern) {
+    errors.push({
+      message: 'Path parameter should specify characters allowed (pattern).',
+      path,
+    });
+  }
+
+  return errors;
+};

--- a/functions/path-param-schema.js
+++ b/functions/path-param-schema.js
@@ -1,3 +1,5 @@
+const URL_MAX_LENGTH = 2083;
+
 // `given` is a (resolved) parameter entry at the path or operation level
 module.exports = (param, _opts, paths) => {
   if (param === null || typeof param !== 'object') {
@@ -36,6 +38,11 @@ module.exports = (param, _opts, paths) => {
   } else if (!schema.maxLength) {
     errors.push({
       message: 'Path parameter should specify a maximum length (maxLength).',
+      path,
+    });
+  } else if (schema.maxLength && schema.maxLength >= URL_MAX_LENGTH) {
+    errors.push({
+      message: `Path parameter maximum length should be less than ${URL_MAX_LENGTH}`,
       path,
     });
   } else if (!schema.pattern) {

--- a/openapi-style-guide.md
+++ b/openapi-style-guide.md
@@ -185,6 +185,11 @@ Format must be one of the values [defined by OpenAPI][openapi-data-types] or rec
 
 Required parameters should not specify a default value.
 
+### Path parameters
+
+Path parameters should be defined as `type: string` with a `maxLength` and a `pattern` that restricts
+the characters that can be be used in the parameter value.
+
 <!-- --------------------------------------------------------------- -->
 
 ## Schemas

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -11,6 +11,7 @@ functions:
   - param-names-unique
   - param-order
   - patch-content-type
+  - path-param-schema
   - version-policy
 rules:
   info-contact: off
@@ -248,6 +249,17 @@ rules:
         # Check each path segment individually and ignore param segments
         # Note: the ':' is only allowed in the final path segment
         match: '^(/([0-9A-Za-z._~-]+|{[^}]+}))*(/([0-9A-Za-z._~:-]+|{[^}]*}(:[0-9A-Za-z._~-]+)?))$'
+
+  az-path-parameter-schema:
+    description: 'Path parameter should be type: string and specify maxLength and pattern.'
+    message: '{{error}}'
+    severity: info
+    formats: ['oas2', 'oas3']
+    given:
+    - $.paths[*].parameters[?(@.in == 'path')]
+    - $.paths.*[get,put,post,patch,delete,options,head].parameters[?(@.in == 'path')]
+    then:
+      function: path-param-schema
 
   az-post-201-response:
     description: Using post for a create operation is discouraged.

--- a/test/path-param-schema.test.js
+++ b/test/path-param-schema.test.js
@@ -24,7 +24,7 @@ test('az-path-parameter-schema should find errors', () => {
           },
         ],
       },
-      '/bar/{p2}/baz/{p3}': {
+      '/bar/{p2}/baz/{p3}/foo/{p4}': {
         get: {
           parameters: [
             {
@@ -35,6 +35,12 @@ test('az-path-parameter-schema should find errors', () => {
               in: 'path',
               type: 'string',
               maxLength: 50,
+            },
+            {
+              name: 'p4',
+              in: 'path',
+              type: 'string',
+              maxLength: 2083,
             },
           ],
         },
@@ -49,16 +55,18 @@ test('az-path-parameter-schema should find errors', () => {
     },
   };
   return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(4);
+    expect(results.length).toBe(5);
     expect(results[0].path.join('.')).toBe('paths./foo/{p1}.parameters.0');
     expect(results[0].message).toContain('should specify a maximum length');
     expect(results[0].message).toContain('and characters allowed');
     expect(results[1].path.join('.')).toBe('paths./foo/{p1}.parameters.0.type');
     expect(results[1].message).toContain('should be defined as type: string');
-    expect(results[2].path.join('.')).toBe('paths./bar/{p2}/baz/{p3}.get.parameters.0');
+    expect(results[2].path.join('.')).toBe('paths./bar/{p2}/baz/{p3}/foo/{p4}.get.parameters.0');
     expect(results[2].message).toContain('should specify a maximum length');
-    expect(results[3].path.join('.')).toBe('paths./bar/{p2}/baz/{p3}.get.parameters.1');
+    expect(results[3].path.join('.')).toBe('paths./bar/{p2}/baz/{p3}/foo/{p4}.get.parameters.1');
     expect(results[3].message).toContain('should specify characters allowed');
+    expect(results[4].path.join('.')).toBe('paths./bar/{p2}/baz/{p3}/foo/{p4}.get.parameters.2');
+    expect(results[4].message).toContain('should be less than');
   });
 });
 

--- a/test/path-param-schema.test.js
+++ b/test/path-param-schema.test.js
@@ -1,0 +1,224 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-path-parameter-schema');
+  return linter;
+});
+
+test('az-path-parameter-schema should find errors', () => {
+  // Test path parameter in 3 different places:
+  // 1. parameter at path level
+  // 2. inline parameter at operation level
+  // 3. referenced parameter at operation level
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/foo/{p1}': {
+        parameters: [
+          {
+            name: 'p1',
+            in: 'path',
+            type: 'integer',
+          },
+        ],
+      },
+      '/bar/{p2}/baz/{p3}': {
+        get: {
+          parameters: [
+            {
+              $ref: '#/parameters/Param2',
+            },
+            {
+              name: 'p3',
+              in: 'path',
+              type: 'string',
+              maxLength: 50,
+            },
+          ],
+        },
+      },
+    },
+    parameters: {
+      Param2: {
+        name: 'p2',
+        in: 'path',
+        type: 'string',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(4);
+    expect(results[0].path.join('.')).toBe('paths./foo/{p1}.parameters.0');
+    expect(results[0].message).toContain('should specify a maximum length');
+    expect(results[0].message).toContain('and characters allowed');
+    expect(results[1].path.join('.')).toBe('paths./foo/{p1}.parameters.0.type');
+    expect(results[1].message).toContain('should be defined as type: string');
+    expect(results[2].path.join('.')).toBe('paths./bar/{p2}/baz/{p3}.get.parameters.0');
+    expect(results[2].message).toContain('should specify a maximum length');
+    expect(results[3].path.join('.')).toBe('paths./bar/{p2}/baz/{p3}.get.parameters.1');
+    expect(results[3].message).toContain('should specify characters allowed');
+  });
+});
+
+test('az-path-parameter-schema should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/foo/{p1}': {
+        parameters: [
+          {
+            name: 'p1',
+            in: 'path',
+            type: 'string',
+            maxLength: 50,
+            pattern: '/[a-z]+/',
+          },
+        ],
+      },
+      '/bar/{p2}/baz/{p3}': {
+        get: {
+          parameters: [
+            {
+              $ref: '#/parameters/Param2',
+            },
+            {
+              name: 'p3',
+              in: 'path',
+              type: 'string',
+              maxLength: 50,
+              pattern: '/[a-z]+/',
+            },
+          ],
+        },
+      },
+    },
+    parameters: {
+      Param2: {
+        name: 'p2',
+        in: 'path',
+        type: 'string',
+        maxLength: 50,
+        pattern: '/[a-z]+/',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});
+
+test('az-path-parameter-schema should find oas3 errors', () => {
+  const oasDoc = {
+    openapi: '3.0',
+    paths: {
+      '/foo/{p1}': {
+        parameters: [
+          {
+            name: 'p1',
+            in: 'path',
+            schema: {
+              type: 'integer',
+            },
+          },
+        ],
+      },
+      '/bar/{p2}/baz/{p3}': {
+        get: {
+          parameters: [
+            {
+              $ref: '#/components/parameters/Param2',
+            },
+            {
+              name: 'p3',
+              in: 'path',
+              schema: {
+                type: 'string',
+                maxLength: 50,
+              },
+            },
+          ],
+        },
+      },
+    },
+    components: {
+      parameters: {
+        Param2: {
+          name: 'p2',
+          in: 'path',
+          schema: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(4);
+    expect(results[0].path.join('.')).toBe('paths./foo/{p1}.parameters.0.schema');
+    expect(results[0].message).toContain('should specify a maximum length');
+    expect(results[0].message).toContain('and characters allowed');
+    expect(results[1].path.join('.')).toBe('paths./foo/{p1}.parameters.0.schema.type');
+    expect(results[1].message).toContain('should be defined as type: string');
+    expect(results[2].path.join('.')).toBe('paths./bar/{p2}/baz/{p3}.get.parameters.0.schema');
+    expect(results[2].message).toContain('should specify a maximum length');
+    expect(results[3].path.join('.')).toBe('paths./bar/{p2}/baz/{p3}.get.parameters.1.schema');
+    expect(results[3].message).toContain('should specify characters allowed');
+  });
+});
+
+test('az-path-parameter-schema should find no oas3 errors', () => {
+  const oasDoc = {
+    openapi: '3.0',
+    paths: {
+      '/foo/{p1}': {
+        parameters: [
+          {
+            name: 'p1',
+            in: 'path',
+            schema: {
+              type: 'string',
+              maxLength: 50,
+              pattern: '/[a-z]+/',
+            },
+          },
+        ],
+      },
+      '/bar/{p2}/baz/{p3}': {
+        get: {
+          parameters: [
+            {
+              $ref: '#/components/parameters/Param2',
+            },
+            {
+              name: 'p3',
+              in: 'path',
+              schema: {
+                type: 'string',
+                maxLength: 50,
+                pattern: '/[a-z]+/',
+              },
+            },
+          ],
+        },
+      },
+    },
+    components: {
+      parameters: {
+        Param2: {
+          name: 'p2',
+          in: 'path',
+          schema: {
+            type: 'string',
+            maxLength: 50,
+            pattern: '/[a-z]+/',
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR adds a rule to check that path parameters are type: string and specify a maxLength and pattern to define the set of allowed characters.