### PR TITLE
Add az-path-parameter-names rule with doc and tests.

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -146,6 +146,10 @@ Only patch operations should accept JSON merge patch.
 
 Service-defined path segments should be restricted to 0-9 A-Z a-z - . _ ~, with : allowed only as described below to designate an action operation.
 
+### az-path-parameter-names
+
+Path parameter names should be consistent across all paths.
+
 ### az-path-parameter-schema
 
 Path parameters should be defined as `type: string` with a `maxLength` and a `pattern` that restricts

--- a/functions/path-param-names.js
+++ b/functions/path-param-names.js
@@ -1,0 +1,44 @@
+// Check that path parameter names are consistent across all paths.
+
+// `given` is the paths object
+module.exports = (paths) => {
+  if (paths === null || typeof paths !== 'object') {
+    return [];
+  }
+
+  const errors = [];
+
+  // Dict to accumulate the parameter name associated with a path segment
+  const paramNameForSegment = {};
+
+  // Identify inconsistent names by iterating over all paths and building up a
+  // dictionary that maps a static path segment to the path parameter that
+  // immediately follows that segment. We issue the message when we find
+  // a static path segment that precedes a path parameter name that is
+  // different from one previously stored in the dictionary.
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const pathKey of Object.keys(paths)) {
+    const parts = pathKey.split('/').slice(1);
+
+    parts.slice(1).forEach((v, i) => {
+      if (v.includes('}')) {
+        const param = v.match(/[^{}]+(?=})/)[0];
+        // Get the preceding path segment
+        const p = parts[i];
+        if (paramNameForSegment[p]) {
+          if (paramNameForSegment[p] !== param) {
+            errors.push({
+              message: `Inconsistent path parameter names "${param}" and "${paramNameForSegment[p]}".`,
+              path: ['paths', pathKey],
+            });
+          }
+        } else {
+          paramNameForSegment[p] = param;
+        }
+      }
+    });
+  }
+
+  return errors;
+};

--- a/openapi-style-guide.md
+++ b/openapi-style-guide.md
@@ -170,6 +170,8 @@ Example:
 
 All parameter names for an operation -- including parameters defined at the path level -- should be case-insensitive unique.
 
+Path parameter names should be consistent across all paths.
+
 ### Parameter order
 
 Path parameters should be in the same order as they appear in the path.

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -12,6 +12,7 @@ functions:
   - param-order
   - patch-content-type
   - path-param-schema
+  - path-param-names
   - version-policy
 rules:
   info-contact: off
@@ -225,6 +226,15 @@ rules:
     given: $.paths
     then:
       function: param-order
+
+  az-path-parameter-names:
+    description: Path parameter names should be consistent across all paths.
+    message: '{{error}}'
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given: $.paths
+    then:
+      function: path-param-names
 
   # Patch request body content type should be application/merge-patch+json
   az-patch-content-type:

--- a/test/path-param-names.test.js
+++ b/test/path-param-names.test.js
@@ -1,0 +1,72 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-path-parameter-names');
+  return linter;
+});
+
+test('az-path-parameter-names should find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/foo/{p1}': {},
+      '/foo/{p2}/bar/{p3}': {},
+      '/bar/{p4}': {},
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    expect(results[0].path.join('.')).toBe('paths./foo/{p2}/bar/{p3}');
+    expect(results[0].message).toContain('Inconsistent path parameter names "p2" and "p1"');
+    expect(results[1].path.join('.')).toBe('paths./bar/{p4}');
+    expect(results[1].message).toContain('Inconsistent path parameter names "p4" and "p3"');
+  });
+});
+
+test('az-path-parameter-names should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/foo/{p1}': {},
+      '/foo/{p1}/bar/{p2}': {},
+      '/bar/{p2}': {},
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});
+
+test('az-path-parameter-names should find oas3 errors', () => {
+  const oasDoc = {
+    openapi: '3.0',
+    paths: {
+      '/foo/{p1}': {},
+      '/foo/{p2}/bar/{p3}': {},
+      '/bar/{p4}': {},
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    expect(results[0].path.join('.')).toBe('paths./foo/{p2}/bar/{p3}');
+    expect(results[0].message).toContain('Inconsistent path parameter names "p2" and "p1"');
+    expect(results[1].path.join('.')).toBe('paths./bar/{p4}');
+    expect(results[1].message).toContain('Inconsistent path parameter names "p4" and "p3"');
+  });
+});
+
+test('az-path-parameter-names should find no oas3 errors', () => {
+  const oasDoc = {
+    openapi: '3.0',
+    paths: {
+      '/foo/{p1}': {},
+      '/foo/{p1}/bar/{p2}': {},
+      '/bar/{p2}': {},
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR adds a rule to check that path parameter names are consistent across all paths.

The rationale for this rule is that a path parameter is generally a "resource id" -- specifically for the resource named by the path segment that immediately precedes the parameter in the path. And we should use a consistent name for this id across all the paths.