### PR TITLE
Check properties exists in responseSchema before access

### DIFF
--- a/functions/pagination-response.js
+++ b/functions/pagination-response.js
@@ -32,7 +32,7 @@ module.exports = (operation, _opts, paths) => {
 
   if (operation['x-ms-pageable']) {
     // Check value property
-    if ('value' in responseSchema.properties) {
+    if (responseSchema.properties && 'value' in responseSchema.properties) {
       if (responseSchema.properties.value.type !== 'array') {
         errors.push({
           message: '`value` property in pageable response should be type: array',
@@ -45,7 +45,7 @@ module.exports = (operation, _opts, paths) => {
           path: [...path, 'responses', resp, 'schema', 'required'],
         });
       }
-    } else {
+    } else if (!responseSchema.allOf) { // skip error for missing value -- it might be in allOf
       errors.push({
         message: 'Response body schema of pageable response should contain top-level array property `value`',
         path: [...path, 'responses', resp, 'schema', 'properties'],
@@ -53,7 +53,7 @@ module.exports = (operation, _opts, paths) => {
     }
     // Check nextLink property
     const nextLinkName = operation['x-ms-pageable'].nextLinkName || 'nextLink';
-    if (nextLinkName in responseSchema.properties) {
+    if (responseSchema.properties && nextLinkName in responseSchema.properties) {
       if (responseSchema.properties[nextLinkName].type !== 'string') {
         errors.push({
           message: `\`${nextLinkName}\` property in pageable response should be type: string`,
@@ -66,7 +66,7 @@ module.exports = (operation, _opts, paths) => {
           path: [...path, 'responses', resp, 'schema', 'required'],
         });
       }
-    } else {
+    } else if (!responseSchema.allOf) { // skip error for missing nextLink -- it might be in allOf
       errors.push({
         message: `Response body schema of pageable response should contain top-level property \`${nextLinkName}\``,
         path: [...path, 'responses', resp, 'schema', 'properties'],


### PR DESCRIPTION
This PR eliminates the crash that was occurring in the `pagination-response` function when the response schema did not have `properties`.  All the properties of the schema are within the child schemas of an `allOf`.

I opened #57 to track the work for `pagination-response` to check in an `allOf` when looking for the `value` and nextLink properties.

This PR just adds guards to ensure that `pagination-response` function does not crash if there is no `properties` object in the response scheam.