### PR TITLE
Add az-api-version-enum rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -26,6 +26,13 @@ What is probably intended is to allow property values of any type, which is best
     "additionalProperties": {}
 ```
 
+### az-api-version-enum
+
+The api-version parameter should not be an enum. This rule is primarily to discourage a practice observed in some APIs
+of defining api-version as an enum with a single value -- the most current API version.
+This requires removing the old API version when a new version is defined,
+which is disallowed by the breaking changes policy.
+
 ### az-consistent-response-body
 
 For a path with a "create" operation (put or patch that returns 201), the 200 response of

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -47,6 +47,17 @@ rules:
     then:
       function: falsy
 
+  az-api-version-enum:
+    description: The api-version parameter should not be an enum.
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given:
+    - $.paths[*].parameters.[?(@.name == 'api-version')]
+    - $.paths.*[get,put,post,patch,delete,options,head].parameters.[?(@.name == 'api-version')]
+    then:
+      field: enum
+      function: falsy
+
   az-consistent-response-body:
     description: Ensure the get, put, and patch response body schemas are consistent.
     message: '{{error}}'


### PR DESCRIPTION
This PR adds a rule to check an api-version parameter for an enum and warn when one is found.