### PR TITLE
Add az-property-type rule

### DIFF
--- a/openapi-style-guide.md
+++ b/openapi-style-guide.md
@@ -209,7 +209,9 @@ Every schema should have a description or a title.
 
 Every schema property should have a description.
 
-### Format
+### Type and format
+
+Every schema should specify an explicit type (some exceptions allowed for "any" type).
 
 Format must be one of the values [defined by OpenAPI][openapi-data-types] or recognized by the Azure tooling.
 

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -305,6 +305,16 @@ rules:
       functionOptions:
         type: camel
 
+  az-property-type:
+    description: All schema properties should have a defined type.
+    message: Property should have a defined type.
+    severity: warn
+    resolved: false
+    given: $..properties[?(@object() && @.$ref == undefined)]
+    then:
+      field: type
+      function: truthy
+
   az-put-path:
     description: The path for a put should have a final path parameter.
     message: The path for a put should have a final path parameter.


### PR DESCRIPTION
This PR adds the az-property-type rule that warns on any named property (not additionalProperties) that does not specify a `type`.