### PR TITLE
Add az-ms-client-flatten rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -86,6 +86,10 @@ Operations with a 202 response should specify `x-ms-long-running-operation: true
 
 A 202 response should include an Operation-Location response header.
 
+### az-ms-client-flatten
+
+The use of the autorest `x-ms-client-flatten` extension is discouraged.
+
 ### az-ms-paths
 
 Don't use the Autorest `x-ms-paths` extension except where necessary to support legacy APIs.

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -146,6 +146,15 @@ rules:
       field: schema
       function: falsy
 
+  az-ms-client-flatten:
+    description: The use of x-ms-client-flatten extension is discouraged.
+    severity: warn
+    formats: ['oas2', 'oas3']
+    resolved: false
+    given: $..x-ms-client-flatten
+    then:
+      function: undefined
+
   az-ms-paths:
     description: Don't use x-ms-paths except where necessary to support legacy APIs.
     severity: warn


### PR DESCRIPTION
Add a simple rule to flag uses of x-ms-client-flatten.  The use of this extension is discouraged because it can cause breaking changes in generated SDK from API changes that are not breaking.