### PR TITLE
Add az-response-body-type rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -196,6 +196,10 @@ RFC7231 states that the payload for both get and delete "has no defined semantic
 
 Flag a body parameter/request body that is not marked as required. This is a common oversight.
 
+### az-response-body-type
+
+Response body schema must not be a bare array.
+
 ### az-schema-description-or-title
 
 All schemas should have a description or title.

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -379,6 +379,17 @@ rules:
       field: required
       function: truthy
 
+  az-response-body-type:
+    description: Response body schema must not be a bare array.
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given: $.paths[*][*][responses][*].schema
+    then:
+      field: type
+      function: pattern
+      functionOptions:
+        notMatch: '/^array$/'
+
   az-schema-description-or-title:
     description: All schemas should have a description or title.
     message: Schema should have a description or title.


### PR DESCRIPTION
This PR adds a simple rule to check the top-level schema of a response body to ensure it is not `type: array`. 

Array types are problematic because you cannot add a property (such as `nextLink`) later without making an incompatible change.

It looks like there are many violations of this rule in existing GA'd Azure services. Here's a sampling:
- specification/cognitiveservices/data-plane/ContentModerator/stable/v1.0/ContentModerator.json
- specification/cognitiveservices/data-plane/CustomVision/Training/stable/v3.3/Training.json
- specification/cognitiveservices/data-plane/Face/stable/v1.0/Face.json
- specification/cognitiveservices/data-plane/LUIS/Authoring/stable/v3.0/LUIS-Authoring.json
- specification/cognitiveservices/data-plane/Personalizer/stable/v1.0/Personalizer.json
- specification/cognitiveservices/data-plane/Speech/SpeechToText/stable/v3.0/speechtotext.json
- specification/cognitiveservices/data-plane/TranslatorText/stable/v3.0/TranslatorText.json
