### PR TITLE
Add az-security-definitions rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -212,6 +212,15 @@ All schemas should have a description or title.
 
 Schema names should be Pascal case.
 
+### az-security-definitions
+
+Security definitions must be present and cannot be empty.
+
+Security definitions must be either type: oauth2 or type: apiKey with in: header.
+
+An oauth2 security scheme must define at least one scope, and all scopes must have a name that matches:
+- https:\/\/[\w-]+(\.[\w-]+)+/[\w-.]+
+
 ### az-security-definition-description
 
 Security definition / security scheme should have a description.

--- a/functions/security-definitions.js
+++ b/functions/security-definitions.js
@@ -28,6 +28,8 @@ module.exports = (doc) => {
 
   Object.keys(schemes).forEach((schemeKey) => {
     const scheme = schemes[schemeKey];
+    // Silently ignore scheme if not an object -- oas2-schema will flag this as an error.
+    // The check here is just to avoid runtime exceptions.
     if (typeof scheme === 'object') {
       const path = ['securityDefinitions', schemeKey];
       if (scheme.type === 'oauth2') {

--- a/functions/security-definitions.js
+++ b/functions/security-definitions.js
@@ -1,0 +1,67 @@
+// Check API definition to ensure conformance to Azure security schemes guidelines.
+
+// Check:
+// - There is at least one security scheme.
+// - All security schemes are either:
+//   - type: oauth2 or
+//   - type: apiKey with in: header
+// - An oauth2 security scheme defines at least one scope.
+// - All scopes defined in an oauth2 security scheme match a pattern:
+//   - https:\/\/[\w-]+(\.[\w-]+)+/[\w-.]+
+
+// @param doc - the entire API document
+module.exports = (doc) => {
+  if (doc === null || typeof doc !== 'object') {
+    return [];
+  }
+
+  if (!doc.securityDefinitions || (typeof doc.securityDefinitions === 'object' && Object.keys(doc.securityDefinitions).length === 0)) {
+    return [{
+      message: 'At least one security scheme must be defined.',
+      path: ['securityDefinitions'],
+    }];
+  }
+
+  const schemes = doc.securityDefinitions;
+
+  const errors = [];
+
+  Object.keys(schemes).forEach((schemeKey) => {
+    const scheme = schemes[schemeKey];
+    if (typeof scheme === 'object') {
+      const path = ['securityDefinitions', schemeKey];
+      if (scheme.type === 'oauth2') {
+        if (!scheme.scopes || (typeof scheme.scopes === 'object' && Object.keys(scheme.scopes).length === 0)) {
+          errors.push({
+            message: 'Security scheme with type: oauth2 should have non-empty "scopes" array.',
+            path: [...path, 'scopes'],
+          });
+        } else {
+          // All scopes must match the pattern
+          Object.keys(scheme.scopes).forEach((scope) => {
+            if (!scope.match(/^https:\/\/[\w-]+(\.[\w-]+)+\/[\w-.]+$/)) {
+              errors.push({
+                message: 'Oauth2 scope names should have the form: https://<audience>/<permission>',
+                path: [...path, 'scopes', scope],
+              });
+            }
+          });
+        }
+      } else if (scheme.type === 'apiKey') {
+        if (scheme.in !== 'header') {
+          errors.push({
+            message: 'Security scheme with type "apiKey" should specify "in: header".',
+            path: [...path, 'in'],
+          });
+        }
+      } else {
+        errors.push({
+          message: 'Security scheme must be type: oauth2 or type: apiKey.',
+          path: [...path, 'type'],
+        });
+      }
+    }
+  });
+
+  return errors;
+};

--- a/openapi-style-guide.md
+++ b/openapi-style-guide.md
@@ -215,6 +215,28 @@ Every schema should specify an explicit type (some exceptions allowed for "any" 
 
 Format must be one of the values [defined by OpenAPI][openapi-data-types] or recognized by the Azure tooling.
 
+<!-- --------------------------------------------------------------- -->
+
+## Security
+
+### Security Definitions
+
+Every API definition must have a `securityDefinitions` section with at least one valid security scheme.
+
+Each security scheme must have a `type` of "oauth2" or "apiKey" with `in` "header".
+
+Each security scheme must have a `description` with a plain English explanation of the security scheme.
+
+For "oauth2" security schemes, `scopes` must contain at least one entry.
+
+The key of each entry in `scopes` must be of the form "<resource URI>/scope name", where "scope name" is typically ".default" for Azure services.
+
+### Security Requirements
+
+Every operation must have a `security`, or there must be a global `security`, with at least one entry.
+
+Every entry of a global or operation `security` must reference a security scheme in the `securityDefinitions`.
+
 <!-- Links -->
 
 [openapi-data-types]: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#data-types

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -13,6 +13,7 @@ functions:
   - patch-content-type
   - path-param-schema
   - path-param-names
+  - security-definitions
   - version-policy
 rules:
   info-contact: off
@@ -432,6 +433,15 @@ rules:
     then:
       field: description
       function: truthy
+
+  az-security-definitions:
+    description: Security definitions must follow Azure conventions.
+    message: '{{error}}'
+    severity: warn
+    formats: ['oas2']
+    given: $
+    then:
+      function: security-definitions
 
   # All success responses except 202 & 204 should define a response body
   # ref: https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#1321-put

--- a/test/security-definitions.test.js
+++ b/test/security-definitions.test.js
@@ -1,0 +1,160 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-security-definitions');
+  return linter;
+});
+
+test('az-security-definitions should find errors when securityDefinitions is missing', () => {
+  const oasDoc = {
+    swagger: '2.0',
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    expect(results[0].path.length).toBe(0);
+    expect(results[0].message).toContain('At least one security scheme must be defined');
+  });
+});
+
+test('az-security-definitions should find errors when securityDefinitions has no entries', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    securityDefinitions: {},
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    expect(results[0].path.join('.')).toBe('securityDefinitions');
+    expect(results[0].message).toContain('At least one security scheme must be defined');
+  });
+});
+
+// Test for security scheme with type: oauth2
+test('az-security-definitions should find errors when securityDefinitions has oauth2 scheme with no scopes', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    securityDefinitions: {
+      oauth2: {
+        type: 'oauth2',
+        flow: 'implicit',
+        authorizationUrl: 'https://example.com/oauth2/authorize',
+        tokenUrl: 'https://example.com/oauth2/token',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    expect(results[0].path.join('.')).toBe('securityDefinitions.oauth2');
+    expect(results[0].message).toContain('Security scheme with type: oauth2 should have non-empty "scopes" array.');
+  });
+});
+
+// Test for security scheme with type: oauth2 with empty scopes
+test('az-security-definitions should find errors when securityDefinitions has oauth2 scheme with empty scopes', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    securityDefinitions: {
+      oauth2: {
+        type: 'oauth2',
+        flow: 'implicit',
+        authorizationUrl: 'https://example.com/oauth2/authorize',
+        tokenUrl: 'https://example.com/oauth2/token',
+        scopes: {},
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    expect(results[0].path.join('.')).toBe('securityDefinitions.oauth2.scopes');
+    expect(results[0].message).toContain('Security scheme with type: oauth2 should have non-empty "scopes" array.');
+  });
+});
+
+// Test for security scheme with type: oauth2 with scopes that do not match the pattern
+test('az-security-definitions should find errors when oauth2 scheme scopes do not match the pattern', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    securityDefinitions: {
+      oauth2: {
+        type: 'oauth2',
+        flow: 'implicit',
+        authorizationUrl: 'https://example.com/oauth2/authorize',
+        tokenUrl: 'https://example.com/oauth2/token',
+        scopes: {
+          read: 'Read access to protected resources',
+          write: 'Write access to protected resources',
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    expect(results[0].path.join('.')).toBe('securityDefinitions.oauth2.scopes.read');
+    expect(results[0].message).toContain('Oauth2 scope names should have the form: https://<audience>/<permission>');
+    expect(results[1].path.join('.')).toBe('securityDefinitions.oauth2.scopes.write');
+  });
+});
+
+// Test for security scheme with type: apiKey but not in: header
+test('az-security-definitions should find errors when apiKey scheme is not in header', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    securityDefinitions: {
+      apiKey: {
+        type: 'apiKey',
+        in: 'query',
+        name: 'api_key',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    expect(results[0].path.join('.')).toBe('securityDefinitions.apiKey.in');
+    expect(results[0].message).toContain('Security scheme with type "apiKey" should specify "in: header".');
+  });
+});
+
+// Test for security scheme with unsupported type
+test('az-security-definitions should find errors when securityDefinitions has unsupported type', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    securityDefinitions: {
+      unsupported: {
+        type: 'basic',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    expect(results[0].path.join('.')).toBe('securityDefinitions.unsupported.type');
+    expect(results[0].message).toContain('Security scheme must be type: oauth2 or type: apiKey.');
+  });
+});
+
+test('az-security-definitions should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    securityDefinitions: {
+      AzureAuth: {
+        description: 'Azure Active Directory OAuth2 Flow',
+        type: 'oauth2',
+        flow: 'application',
+        tokenUrl:
+          'https://login.microsoftonline.com/common/oauth2/authorize',
+        scopes: {
+          'https://atlas.microsoft.com/.default': 'default permissions to user account',
+        },
+      },
+      ApiKey: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'api_key',
+        description: 'API Key',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR adds the az-security-definitions rule which checks that security schemes in `securityDefinitions` contain the information needed by autorest to produce client libraries with the correct authentication features.

This is a new requirement for data plane codegen and currently most Azure services are not in compliance, particularly in regard to the presence of scopes and pattern of scope names.