### PR TITLE
Improve the az-path-param-names rule

### DIFF
--- a/functions/path-param-names.js
+++ b/functions/path-param-names.js
@@ -1,4 +1,7 @@
 // Check that path parameter names are consistent across all paths.
+// Specifically:
+// - The path parameter that follows a static path segment must be the same across all paths
+// - The static path segment that precedes a path parameter must be the same across all paths
 
 // `given` is the paths object
 module.exports = (paths) => {
@@ -10,6 +13,8 @@ module.exports = (paths) => {
 
   // Dict to accumulate the parameter name associated with a path segment
   const paramNameForSegment = {};
+  // Dict to accumulate the parameter name associated with a path segment
+  const segmentForParamName = {};
 
   // Identify inconsistent names by iterating over all paths and building up a
   // dictionary that maps a static path segment to the path parameter that
@@ -29,12 +34,22 @@ module.exports = (paths) => {
         if (paramNameForSegment[p]) {
           if (paramNameForSegment[p] !== param) {
             errors.push({
-              message: `Inconsistent path parameter names "${param}" and "${paramNameForSegment[p]}".`,
+              message: `Inconsistent parameter names "${paramNameForSegment[p]}" and "${param}" for path segment "${p}".`,
               path: ['paths', pathKey],
             });
           }
         } else {
           paramNameForSegment[p] = param;
+        }
+        if (segmentForParamName[param]) {
+          if (segmentForParamName[param] !== p) {
+            errors.push({
+              message: `Inconsistent path segments "${segmentForParamName[param]}" and "${p}" for parameter "${param}".`,
+              path: ['paths', pathKey],
+            });
+          }
+        } else {
+          segmentForParamName[param] = p;
         }
       }
     });

--- a/functions/path-param-names.js
+++ b/functions/path-param-names.js
@@ -13,7 +13,7 @@ module.exports = (paths) => {
 
   // Dict to accumulate the parameter name associated with a path segment
   const paramNameForSegment = {};
-  // Dict to accumulate the parameter name associated with a path segment
+  // Dict to accumulate the segment name associated with a path parameter
   const segmentForParamName = {};
 
   // Identify inconsistent names by iterating over all paths and building up a

--- a/test/path-param-names.test.js
+++ b/test/path-param-names.test.js
@@ -19,9 +19,27 @@ test('az-path-parameter-names should find errors', () => {
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
     expect(results[0].path.join('.')).toBe('paths./foo/{p2}/bar/{p3}');
-    expect(results[0].message).toContain('Inconsistent path parameter names "p2" and "p1"');
+    expect(results[0].message).toContain('Inconsistent parameter names "p1" and "p2" for path segment "foo".');
     expect(results[1].path.join('.')).toBe('paths./bar/{p4}');
-    expect(results[1].message).toContain('Inconsistent path parameter names "p4" and "p3"');
+    expect(results[1].message).toContain('Inconsistent parameter names "p3" and "p4" for path segment "bar".');
+  });
+});
+
+test('az-path-parameter-names should find a static path segment that is followed by two different path params', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/foo/{p1}': {},
+      '/bar/{p1}/baz/{p2}': {},
+      '/qux/{p2}': {},
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    expect(results[0].path.join('.')).toBe('paths./bar/{p1}/baz/{p2}');
+    expect(results[0].message).toContain('Inconsistent path segments "foo" and "bar" for parameter "p1"');
+    expect(results[1].path.join('.')).toBe('paths./qux/{p2}');
+    expect(results[1].message).toContain('Inconsistent path segments "baz" and "qux" for parameter "p2"');
   });
 });
 
@@ -51,9 +69,9 @@ test('az-path-parameter-names should find oas3 errors', () => {
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2);
     expect(results[0].path.join('.')).toBe('paths./foo/{p2}/bar/{p3}');
-    expect(results[0].message).toContain('Inconsistent path parameter names "p2" and "p1"');
+    expect(results[0].message).toContain('Inconsistent parameter names "p1" and "p2" for path segment "foo".');
     expect(results[1].path.join('.')).toBe('paths./bar/{p4}');
-    expect(results[1].message).toContain('Inconsistent path parameter names "p4" and "p3"');
+    expect(results[1].message).toContain('Inconsistent parameter names "p3" and "p4" for path segment "bar".');
   });
 });
 


### PR DESCRIPTION
This PR improves the az-path-param-names rule by checking that the path segment that precedes a particular path parameter is the same across all paths.  This is the inverse of the check that was already implemented in this rule.

I discovered that this case was missing when reviewing PR 17817.