### PR TITLE
Add az-schema-type-and-format rule with tests and doc

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -220,6 +220,54 @@ All schemas should have a description or title.
 
 Schema names should be Pascal case.
 
+### az-schema-type-and-format
+
+Every schema should specify a well-defined combination of `type` and `format`.
+
+`format` is required for type integer and number, optional for type string,
+and not allowed for any other types.
+
+The well-defined type/format combinations are:
+
+**type: integer**
+
+| format | description | comments |
+| ------ | ----------- | -------- |
+| int32  | signed 32 bits | from [oas2][oas2] |
+| int64  | signed 64 bits | from [oas2][oas2] |
+| unixtime | Unix time stamp | from [autorest][autorest] |
+
+**type: number**
+
+| format | description | comments |
+| ------ | ----------- | -------- |
+| float  | 32 bit floating point | from [oas2][oas2] |
+| int64  | 64 bit floating point | from [oas2][oas2] |
+| decimal | 128 bit floating point | from [autorest][autorest] |
+
+**type: string**
+
+| format | description | comments |
+| ------ | ----------- | -------- |
+| byte  | base64 encoded characters | from [oas2][oas2] |
+| binary  | any sequence of octets | from [oas2][oas2] |
+| date  | [RFC3339][rfc3339] full-date | from [oas2][oas2] |
+| date-time  | [RFC3339][rfc3339] date-time | from [oas2][oas2] |
+| password | sensitive value | from [oas2][oas2] |
+| char |  | from [autorest][autorest] |
+| time |  | from [autorest][autorest] |
+| date-time-rfc1123 |  | from [autorest][autorest] |
+| duration |  | from [autorest][autorest] |
+| uuid |  | from [autorest][autorest] |
+| base64url |  | from [autorest][autorest] |
+| url |  | from [autorest][autorest] |
+| odata-query |  | from [autorest][autorest] |
+| certificate |  | from [autorest][autorest] |
+
+oas2: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#data-types
+autorest: https://github.com/Azure/autorest/blob/main/packages/libs/openapi/src/v3/formats.ts
+rfc3339: https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14
+
 ### az-security-definitions
 
 Security definitions must be present and cannot be empty.

--- a/functions/schema-type-and-format.js
+++ b/functions/schema-type-and-format.js
@@ -1,0 +1,76 @@
+// Check that format is valid for a schema type.
+// Valid formats are those defined in the OpenAPI spec and extensions in autorest.
+// - https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#data-types
+// - https://github.com/Azure/autorest/blob/main/packages/libs/openapi/src/v3/formats.ts
+
+// `input` is the schema of a request or response body
+module.exports = function checkTypeAndFormat(schema, options, { path }) {
+  if (schema === null || typeof schema !== 'object') {
+    return [];
+  }
+
+  const errors = [];
+
+  const stringFormats = [
+    // OAS-defined formats
+    'byte', 'binary', 'date', 'date-time', 'password',
+    // Additional formats recognized by autorest
+    'char', 'time', 'date-time-rfc1123', 'duration', 'uuid', 'base64url', 'url',
+    'odata-query', 'certificate',
+  ];
+
+  if (schema.type === 'string') {
+    if (schema.format) {
+      if (!stringFormats.includes(schema.format)) {
+        errors.push({
+          message: `Schema with type: string has unrecognized format: ${schema.format}`,
+          path: [...path, 'format'],
+        });
+      }
+    }
+  } else if (schema.type === 'integer') {
+    if (schema.format) {
+      if (!['int32', 'int64', 'unixtime'].includes(schema.format)) {
+        errors.push({
+          message: `Schema with type: integer has unrecognized format: ${schema.format}`,
+          path: [...path, 'format'],
+        });
+      }
+    } else {
+      errors.push({
+        message: 'Schema with type: integer should specify format',
+        path,
+      });
+    }
+  } else if (schema.type === 'number') {
+    if (schema.format) {
+      if (!['float', 'double', 'decimal'].includes(schema.format)) {
+        errors.push({
+          message: `Schema with type: number has unrecognized format: ${schema.format}`,
+          path: [...path, 'format'],
+        });
+      }
+    } else {
+      errors.push({
+        message: 'Schema with type: number should specify format',
+        path,
+      });
+    }
+  } else if (schema.type === 'boolean') {
+    if (schema.format) {
+      errors.push({
+        message: 'Schema with type: boolean should not specify format',
+        path: [...path, 'format'],
+      });
+    }
+  } else if (schema.properties && typeof schema.properties === 'object') {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [key, value] of Object.entries(schema.properties)) {
+      errors.push(
+        ...checkTypeAndFormat(value, options, { path: [...path, 'properties', key] }),
+      );
+    }
+  }
+
+  return errors;
+};

--- a/functions/schema-type-and-format.js
+++ b/functions/schema-type-and-format.js
@@ -72,5 +72,14 @@ module.exports = function checkTypeAndFormat(schema, options, { path }) {
     }
   }
 
+  if (schema.allOf && Array.isArray(schema.allOf)) {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [index, value] of schema.allOf.entries()) {
+      errors.push(
+        ...checkTypeAndFormat(value, options, { path: [...path, 'allOf', index] }),
+      );
+    }
+  }
+
   return errors;
 };

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -17,6 +17,7 @@ functions:
   - path-param-names
   - security-definitions
   - security-requirements
+  - schema-type-and-format
   - version-policy
 rules:
   info-contact: off
@@ -442,6 +443,17 @@ rules:
       function: casing
       functionOptions:
         type: pascal
+
+  az-schema-type-and-format:
+    description: Schema should use well-defined type and format.
+    message: '{{error}}'
+    severity: warn
+    formats: ['oas2']
+    given:
+    - $.paths[*].[put,post,patch].parameters.[?(@.in == 'body')].schema
+    - $.paths[*].[get,put,post,patch,delete].responses[*].schema
+    then:
+      function: schema-type-and-format
 
   az-security-definition-description:
     description: A security definition should have a description.

--- a/test/schema-type-and-format.test.js
+++ b/test/schema-type-and-format.test.js
@@ -41,6 +41,16 @@ test('az-schema-type-and-format should find errors', () => {
                     type: 'number',
                   },
                 },
+                allOf: [
+                  {
+                    properties: {
+                      prop5: {
+                        type: 'string',
+                        format: 'email',
+                      },
+                    },
+                  },
+                ],
               },
             },
           ],
@@ -79,15 +89,29 @@ test('az-schema-type-and-format should find errors', () => {
             $ref: '#/definitions/PropZZ',
           },
         },
+        allOf: [
+          {
+            $ref: '#/definitions/ModelA',
+          },
+        ],
       },
       PropZZ: {
         type: 'string',
         format: 'ZZTop',
       },
+      ModelA: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            format: 'guid',
+          },
+        },
+      },
     },
   };
   return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(8);
+    expect(results.length).toBe(10);
     expect(results[0].path.join('.')).toBe('paths./test1.post.parameters.0.schema.properties.prop1.format');
     expect(results[0].message).toBe('Schema with type: integer has unrecognized format: int52');
     expect(results[1].path.join('.')).toBe('paths./test1.post.parameters.0.schema.properties.prop2.properties.prop3.format');
@@ -96,14 +120,18 @@ test('az-schema-type-and-format should find errors', () => {
     expect(results[2].message).toBe('Schema with type: boolean should not specify format');
     expect(results[3].path.join('.')).toBe('paths./test1.post.parameters.0.schema.properties.prop4');
     expect(results[3].message).toBe('Schema with type: number should specify format');
-    expect(results[4].path.join('.')).toBe('paths./test1.post.responses.200.schema.properties.propW.format');
-    expect(results[4].message).toBe('Schema with type: number has unrecognized format: exponential');
-    expect(results[5].path.join('.')).toBe('paths./test1.post.responses.200.schema.properties.propX.properties.propY.format');
-    expect(results[5].message).toBe('Schema with type: string has unrecognized format: secret');
-    expect(results[6].path.join('.')).toBe('paths./test1.post.responses.200.schema.properties.propZ');
-    expect(results[6].message).toBe('Schema with type: integer should specify format');
-    expect(results[7].path.join('.')).toBe('paths./test1.post.responses.200.schema.properties.propZZ.format');
-    expect(results[7].message).toBe('Schema with type: string has unrecognized format: ZZTop');
+    expect(results[4].path.join('.')).toBe('paths./test1.post.parameters.0.schema.allOf.0.properties.prop5.format');
+    expect(results[4].message).toBe('Schema with type: string has unrecognized format: email');
+    expect(results[5].path.join('.')).toBe('paths./test1.post.responses.200.schema.allOf.0.properties.id.format');
+    expect(results[5].message).toBe('Schema with type: string has unrecognized format: guid');
+    expect(results[6].path.join('.')).toBe('paths./test1.post.responses.200.schema.properties.propW.format');
+    expect(results[6].message).toBe('Schema with type: number has unrecognized format: exponential');
+    expect(results[7].path.join('.')).toBe('paths./test1.post.responses.200.schema.properties.propX.properties.propY.format');
+    expect(results[7].message).toBe('Schema with type: string has unrecognized format: secret');
+    expect(results[8].path.join('.')).toBe('paths./test1.post.responses.200.schema.properties.propZ');
+    expect(results[8].message).toBe('Schema with type: integer should specify format');
+    expect(results[9].path.join('.')).toBe('paths./test1.post.responses.200.schema.properties.propZZ.format');
+    expect(results[9].message).toBe('Schema with type: string has unrecognized format: ZZTop');
   });
 });
 
@@ -141,6 +169,15 @@ test('az-schema-type-and-format should find no errors', () => {
                     format: 'float',
                   },
                 },
+                allOf: [
+                  {
+                    properties: {
+                      prop5: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                ],
               },
             },
           ],
@@ -180,10 +217,24 @@ test('az-schema-type-and-format should find no errors', () => {
             $ref: '#/definitions/PropZZ',
           },
         },
+        allOf: [
+          {
+            $ref: '#/definitions/ModelA',
+          },
+        ],
       },
       PropZZ: {
         type: 'string',
         format: 'url',
+      },
+      ModelA: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
       },
     },
   };

--- a/test/schema-type-and-format.test.js
+++ b/test/schema-type-and-format.test.js
@@ -1,0 +1,193 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-schema-type-and-format');
+  return linter;
+});
+
+test('az-schema-type-and-format should find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        post: {
+          parameters: [
+            {
+              name: 'version',
+              in: 'body',
+              schema: {
+                type: 'object',
+                properties: {
+                  prop1: {
+                    type: 'integer',
+                    format: 'int52',
+                  },
+                  prop2: {
+                    type: 'object',
+                    properties: {
+                      prop3: {
+                        type: 'string',
+                        format: 'special',
+                      },
+                    },
+                  },
+                  prop3: {
+                    type: 'boolean',
+                    format: 'yes-or-no',
+                  },
+                  prop4: {
+                    type: 'number',
+                  },
+                },
+              },
+            },
+          ],
+          responses: {
+            200: {
+              description: 'Success',
+              schema: {
+                $ref: '#/definitions/Model1',
+              },
+            },
+          },
+        },
+      },
+    },
+    definitions: {
+      Model1: {
+        type: 'object',
+        properties: {
+          propW: {
+            type: 'number',
+            format: 'exponential',
+          },
+          propX: {
+            type: 'object',
+            properties: {
+              propY: {
+                type: 'string',
+                format: 'secret',
+              },
+            },
+          },
+          propZ: {
+            type: 'integer',
+          },
+          propZZ: {
+            $ref: '#/definitions/PropZZ',
+          },
+        },
+      },
+      PropZZ: {
+        type: 'string',
+        format: 'ZZTop',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(8);
+    expect(results[0].path.join('.')).toBe('paths./test1.post.parameters.0.schema.properties.prop1.format');
+    expect(results[0].message).toBe('Schema with type: integer has unrecognized format: int52');
+    expect(results[1].path.join('.')).toBe('paths./test1.post.parameters.0.schema.properties.prop2.properties.prop3.format');
+    expect(results[1].message).toBe('Schema with type: string has unrecognized format: special');
+    expect(results[2].path.join('.')).toBe('paths./test1.post.parameters.0.schema.properties.prop3.format');
+    expect(results[2].message).toBe('Schema with type: boolean should not specify format');
+    expect(results[3].path.join('.')).toBe('paths./test1.post.parameters.0.schema.properties.prop4');
+    expect(results[3].message).toBe('Schema with type: number should specify format');
+    expect(results[4].path.join('.')).toBe('paths./test1.post.responses.200.schema.properties.propW.format');
+    expect(results[4].message).toBe('Schema with type: number has unrecognized format: exponential');
+    expect(results[5].path.join('.')).toBe('paths./test1.post.responses.200.schema.properties.propX.properties.propY.format');
+    expect(results[5].message).toBe('Schema with type: string has unrecognized format: secret');
+    expect(results[6].path.join('.')).toBe('paths./test1.post.responses.200.schema.properties.propZ');
+    expect(results[6].message).toBe('Schema with type: integer should specify format');
+    expect(results[7].path.join('.')).toBe('paths./test1.post.responses.200.schema.properties.propZZ.format');
+    expect(results[7].message).toBe('Schema with type: string has unrecognized format: ZZTop');
+  });
+});
+
+test('az-schema-type-and-format should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        post: {
+          parameters: [
+            {
+              name: 'version',
+              in: 'body',
+              schema: {
+                type: 'object',
+                properties: {
+                  prop1: {
+                    type: 'integer',
+                    format: 'int64',
+                  },
+                  prop2: {
+                    type: 'object',
+                    properties: {
+                      prop3: {
+                        type: 'string',
+                        format: 'byte',
+                      },
+                    },
+                  },
+                  prop3: {
+                    type: 'boolean',
+                  },
+                  prop4: {
+                    type: 'number',
+                    format: 'float',
+                  },
+                },
+              },
+            },
+          ],
+          responses: {
+            200: {
+              description: 'Success',
+              schema: {
+                $ref: '#/definitions/Model1',
+              },
+            },
+          },
+        },
+      },
+    },
+    definitions: {
+      Model1: {
+        type: 'object',
+        properties: {
+          propW: {
+            type: 'number',
+            format: 'double',
+          },
+          propX: {
+            type: 'object',
+            properties: {
+              propY: {
+                type: 'string',
+                format: 'duration',
+              },
+            },
+          },
+          propZ: {
+            type: 'integer',
+            format: 'int32',
+          },
+          propZZ: {
+            $ref: '#/definitions/PropZZ',
+          },
+        },
+      },
+      PropZZ: {
+        type: 'string',
+        format: 'url',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR adds a rule to check that the type and format combination for a schema is well-defined.