### PR TITLE
Disable oas3 format for rules that now fail for oas3

### DIFF
--- a/spectral.yaml
+++ b/spectral.yaml
@@ -54,7 +54,8 @@ rules:
   az-api-version-enum:
     description: The api-version parameter should not be an enum.
     severity: warn
-    formats: ['oas2', 'oas3']
+    # oas3 support has broken - disable for now
+    formats: ['oas2']
     given:
     - $.paths[*].parameters.[?(@.name == 'api-version')]
     - $.paths.*[get,put,post,patch,delete,options,head].parameters.[?(@.name == 'api-version')]
@@ -110,7 +111,8 @@ rules:
     description: Authorization, Content-type, and Accept headers should not be defined explicitly.
     message: 'Header parameter "{{value}}" should not be defined explicitly.'
     severity: warn
-    formats: ['oas2', 'oas3']
+    # oas3 support has broken - disable for now
+    formats: ['oas2']
     given:
     - $.paths[*].parameters.[?(@.in == 'header')]
     - $.paths.*[get,put,post,patch,delete,options,head].parameters.[?(@.in == 'header')]
@@ -243,6 +245,8 @@ rules:
   az-parameter-default-not-allowed:
     description: A required parameter should not specify a default value.
     severity: warn
+    # oas3 support has broken - restrict to oas2 for now
+    formats: ['oas2']
     given:
     - $.paths[*].parameters.[?(@.required)]
     - $.paths.*[get,put,post,patch,delete,options,head].parameters.[?(@.required)]
@@ -480,7 +484,8 @@ rules:
     description: The security requirement should reference a defined security scheme.
     message: '{{error}}'
     severity: warn
-    formats: ['oas2','oas3']
+    # Drop oas3 format for now
+    formats: ['oas2']
     given:
     - $.security
     - $.paths.*[get,put,post,patch,delete,options,head].security

--- a/test/security-requirements.test.js
+++ b/test/security-requirements.test.js
@@ -29,29 +29,29 @@ test('az-security-requirements should find errors', () => {
   });
 });
 
-test('az-security-requirements should find oas3 errors', () => {
-  const oasDoc = {
-    openapi: '3.0.0',
-    components: {
-      securitySchemes: {
-        jwt: {
-          type: 'http',
-          scheme: 'bearer',
-          bearerFormat: 'JWT',
-        },
-      },
-    },
-    security: [
-      {
-        AADToken: ['read', 'write'],
-      },
-    ],
-  };
-  return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(1);
-    expect(results[0].path.join('.')).toBe('security.0.AADToken');
-  });
-});
+// test('az-security-requirements should find oas3 errors', () => {
+//   const oasDoc = {
+//     openapi: '3.0.0',
+//     components: {
+//       securitySchemes: {
+//         jwt: {
+//           type: 'http',
+//           scheme: 'bearer',
+//           bearerFormat: 'JWT',
+//         },
+//       },
+//     },
+//     security: [
+//       {
+//         AADToken: ['read', 'write'],
+//       },
+//     ],
+//   };
+//   return linter.run(oasDoc).then((results) => {
+//     expect(results.length).toBe(1);
+//     expect(results[0].path.join('.')).toBe('security.0.AADToken');
+//   });
+// });
 
 test('az-security-requirements should find undefined scope', () => {
   const oasDoc = {
@@ -286,26 +286,26 @@ test('az-security-requirements should find no errors', () => {
   });
 });
 
-test('az-security-requirements should find no oas3 errors', () => {
-  const oasDoc = {
-    openapi: '3.0.0',
-    components: {
-      securitySchemes: {
-        jwt: {
-          type: 'http',
-          scheme: 'bearer',
-          bearerFormat: 'JWT',
-          description: 'JSON Web Token with credentials for the service',
-        },
-      },
-    },
-    security: [
-      {
-        jwt: [],
-      },
-    ],
-  };
-  return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(0);
-  });
-});
+// test('az-security-requirements should find no oas3 errors', () => {
+//   const oasDoc = {
+//     openapi: '3.0.0',
+//     components: {
+//       securitySchemes: {
+//         jwt: {
+//           type: 'http',
+//           scheme: 'bearer',
+//           bearerFormat: 'JWT',
+//           description: 'JSON Web Token with credentials for the service',
+//         },
+//       },
+//     },
+//     security: [
+//       {
+//         jwt: [],
+//       },
+//     ],
+//   };
+//   return linter.run(oasDoc).then((results) => {
+//     expect(results.length).toBe(0);
+//   });
+// });


### PR DESCRIPTION
This PR is a temporary workaround for problems with the ruleset when run on an oas3 format API definition.

I've opened #90 to document the problems and we should debug/fix those at some point, but for now this PR just disables these problematic rules for oas3 to allow the rest of the rules to run.