### PR TITLE
Add az-path-case-convention rule and test

### DIFF
--- a/spectral.yaml
+++ b/spectral.yaml
@@ -307,6 +307,20 @@ rules:
     then:
       function: patch-content-type
 
+  # Static path segments should be kebab-case
+  az-path-case-convention:
+    description: Static path segments should be kebab-case.
+    message: Static path segments should be kebab-case.
+    severity: info
+    formats: ['oas2', 'oas3']
+    given: $.paths.*~
+    then:
+      function: pattern
+      functionOptions:
+        # Check each path segment individually and ignore param segments
+        # Note: the ':' is only allowed in the final path segment
+        match: '^(\/([a-z][a-z0-9-]+|{[^}]+}))*\/([a-z][a-z0-9-]+|{[^}]*})?(:[a-z][a-z0-9-]+)?$'
+
   # DO limit your URLs characters to 0-9 A-Z a-z - . _ ~ :
   az-path-characters:
     description: Path should contain only recommended characters.
@@ -319,7 +333,7 @@ rules:
       functionOptions:
         # Check each path segment individually and ignore param segments
         # Note: the ':' is only allowed in the final path segment
-        match: '^(/([0-9A-Za-z._~-]+|{[^}]+}))*(/([0-9A-Za-z._~:-]+|{[^}]*}(:[0-9A-Za-z._~-]+)?))$'
+        match: '^(\/([0-9A-Za-z._~-]+|{[^}]+}))*\/([0-9A-Za-z._~-]+|{[^}]*})?(:[0-9A-Za-z._~-]+)?$'
 
   az-path-parameter-schema:
     description: 'Path parameter should be type: string and specify maxLength and pattern.'

--- a/test/path-case-convention.test.js
+++ b/test/path-case-convention.test.js
@@ -1,0 +1,41 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-path-case-convention');
+  return linter;
+});
+
+test('az-path-case-convention should find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/fooBar': {},
+      '/foo-bar/{id}/barBaz': {},
+      '/foo/{bar}:bazQux': {},
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(3);
+    expect(results[0].path.join('.')).toBe('paths./fooBar');
+    expect(results[1].path.join('.')).toBe('paths./foo-bar/{id}/barBaz');
+    expect(results[2].path.join('.')).toBe('paths./foo/{bar}:bazQux');
+  });
+});
+
+test('az-path-case-convention should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/': {},
+      '/:foobar': {},
+      '/abcdefghijklmnopqrstuvwxyz0123456789': {},
+      '/a0-b1-c2/d3-e4-f5/ghi-jkl-mno/pqrstuvwxyz': {},
+      '/foo/{$#@&^}:bar-baz': {},
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/path-characters.test.js
+++ b/test/path-characters.test.js
@@ -28,6 +28,8 @@ test('az-path-characters should find no errors', () => {
   const oasDoc = {
     swagger: '2.0',
     paths: {
+      '/': {},
+      '/:foobar': {},
       '/abcdefghijklmnopqrstuvwxyz0123456789': {},
       '/A0.B1.C2/D3_E4_F5/GHI-JKL-MNO/~PQRSTUVWXYZ': {},
       '/foo/{$#@&^}:goo': {},


### PR DESCRIPTION
This PR adds the az-path-case-convention rule that checks static path segments to ensure they are kebab-case.