### PR TITLE
Improve style and checks for operationIds

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -112,12 +112,16 @@ The `operationId` should be of the form `Noun_Verb`.  It should contain exactly 
 
 The `Verb` of the `operationId` should be or contain a specific value depending on the operation method:
 
-| operation method | verb should contain | notes  |
-| ---------------- | ------------------- | ------ |
-| get              | "Get" or "List"     | should be "List" if response is pageable |
-| put              | "Create" or "Update" | could be "CreateOrUpdate" |
-| patch            | "Update"            | could be "CreateOrUpdate" |
+| operation method | verb should contain | Notes |
+| ---------------- | ------------------- | ----- |
+| get on a resource | "Get"     | last path segment is parameter |
+| get on a collection | "List"  | last path segment is static |
+| put              | "Create" if operation returns 201<br/>"Replace" if operation returns 200 | could be "CreateOrReplace" |
+| patch            | "Create" if operation returns 201<br/>"Update" if operation returns 201 | could be "CreateOrUpdate" |
 | delete           | "Delete"            | |
+
+Do not use "Post", "Put", or "Patch" in the `operationId`. The `Verb` should convey the action
+performed by the operation rather than the HTTP method used in the request.
 
 ### az-operation-security
 

--- a/openapi-style-guide.md
+++ b/openapi-style-guide.md
@@ -85,14 +85,16 @@ AutoRest breaks the operation id into its `Noun` and `Verb` where `Noun` becomes
 
 The `Verb` of the `operationId` should be or contain a specific value depending on the operation method:
 
-| operation method | verb should contain | notes  |
-| ---------------- | ------------------- | ------ |
-| get              | "Get" or "List"     | should be "List" if response is pageable |
-| put              | "Create" or "Update" | could be "CreateOrUpdate" |
-| patch            | "Update"            | could be "CreateOrUpdate" |
+| operation method | verb should contain | Notes |
+| ---------------- | ------------------- | ----- |
+| get on a resource | "Get"     | last path segment is parameter |
+| get on a collection | "List"  | last path segment is static |
+| put              | "Create" if operation returns 201<br/>"Replace" if operation returns 200 | could be "CreateOrReplace" |
+| patch            | "Create" if operation returns 201<br/>"Update" if operation returns 201 | could be "CreateOrUpdate" |
 | delete           | "Delete"            | |
 
-Further, a put or patch that supports both create and update should have "Create" and "Update" in the verb.
+Do not use "Post", "Put", or "Patch" in the `operationId`. The `Verb` should convey the action
+performed by the operation rather than the HTTP method used in the request.
 
 ### Request body
 

--- a/test/operation-id.test.js
+++ b/test/operation-id.test.js
@@ -11,9 +11,9 @@ test('az-operation-id should find operationId not Noun_Verb', () => {
   const oasDoc = {
     swagger: '2.0',
     paths: {
-      '/api/test1': {
+      '/test1': {
         get: {
-          operationId: 'notNounVerb',
+          operationId: 'ListTests',
         },
         post: {
           operationId: 'fooBarBaz',
@@ -22,72 +22,56 @@ test('az-operation-id should find operationId not Noun_Verb', () => {
     },
   };
   return linter.run(oasDoc).then((results) => {
-    expect(results).toHaveLength(3);
-    expect(results[0].path.join('.')).toBe('paths./api/test1.get.operationId');
-    expect(results[0].message).toBe('OperationId should be of the form "Noun_Verb"');
-    expect(results[1].path.join('.')).toBe('paths./api/test1.get.operationId');
-    expect(results[1].message).toBe('OperationId for get method should contain "Get" or "list"');
-    expect(results[2].path.join('.')).toBe('paths./api/test1.post.operationId');
-    expect(results[2].message).toBe('OperationId should be of the form "Noun_Verb"');
+    expect(results).toHaveLength(2);
+    expect(results[0].path.join('.')).toBe('paths./test1.get.operationId');
+    expect(results[1].path.join('.')).toBe('paths./test1.post.operationId');
+    results.forEach((result) => expect(result.message).toBe(
+      'OperationId should be of the form "Noun_Verb"',
+    ));
   });
 });
 
-test('az-operation-id should find operationId without standard verb', () => {
+test('az-operation-id should find operationId for get without standard verb', () => {
   const oasDoc = {
     swagger: '2.0',
     paths: {
-      '/api/test2': {
+      '/test1': {
         get: {
-          operationId: 'Noun_Verb',
+          operationId: 'GetAll',
         },
-        put: {
-          operationId: 'Noun_Put',
+      },
+      '/test2': {
+        get: {
+          operationId: 'Noun_GetAll',
         },
-        patch: {
-          operationId: 'Noun_Patch',
-        },
-        delete: {
-          operationId: 'Noun_Remove',
+      },
+      '/test2/{id}': {
+        get: {
+          operationId: 'Noun_Read',
         },
       },
     },
   };
   return linter.run(oasDoc).then((results) => {
     expect(results).toHaveLength(4);
-    expect(results[0].path.join('.')).toBe('paths./api/test2.get.operationId');
-    expect(results[1].path.join('.')).toBe('paths./api/test2.put.operationId');
-    expect(results[2].path.join('.')).toBe('paths./api/test2.patch.operationId');
-    expect(results[3].path.join('.')).toBe('paths./api/test2.delete.operationId');
-    results.forEach((result) => expect(result.message).toMatch(
-      /OperationId for (get|put|patch|delete) method should contain/,
-    ));
+    expect(results[0].path.join('.')).toBe('paths./test1.get.operationId');
+    expect(results[0].message).toBe('OperationId should be of the form "Noun_Verb"');
+    expect(results[1].path.join('.')).toBe('paths./test1.get.operationId');
+    expect(results[1].message).toBe('OperationId for get on a collection should contain "list"');
+    expect(results[2].path.join('.')).toBe('paths./test2.get.operationId');
+    expect(results[2].message).toBe('OperationId for get on a collection should contain "list"');
+    expect(results[3].path.join('.')).toBe('paths./test2/{id}.get.operationId');
+    expect(results[3].message).toBe('OperationId for get on a single object should contain "get"');
   });
 });
 
-test('az-operation-id should find operationId without standard verb', () => {
+test('az-operation-id should find operationId for put without standard verb', () => {
   const oasDoc = {
     swagger: '2.0',
     paths: {
-      '/api/test3': {
-        get: {
-          operationId: 'Noun_Get',
-          'x-ms-pageable': {
-            nextLinkName: 'nextLink',
-          },
-        },
+      '/test1/{id}': {
         put: {
-          operationId: 'Noun_Create',
-          responses: {
-            200: {
-              description: 'Success',
-            },
-            201: {
-              description: 'Created',
-            },
-          },
-        },
-        patch: {
-          operationId: 'Noun_Update',
+          operationId: 'CreateNoun',
           responses: {
             200: {
               description: 'Success',
@@ -98,16 +82,222 @@ test('az-operation-id should find operationId without standard verb', () => {
           },
         },
       },
+      // 2: should not have Create
+      '/test2/{id}': {
+        put: {
+          operationId: 'Noun_Submit',
+          responses: {
+            201: {
+              description: 'Created',
+            },
+          },
+        },
+      },
+      // 3: should not have update
+      '/test3/{id}': {
+        put: {
+          operationId: 'Noun_CreateOrReplace',
+          responses: {
+            201: {
+              description: 'Created',
+            },
+          },
+        },
+      },
+      // 4: should have replace
+      '/test4/{id}': {
+        put: {
+          operationId: 'Noun_Fiddle',
+          responses: {
+            200: {
+              description: 'Ok',
+            },
+          },
+        },
+      },
+      // 5: should not have create
+      '/test5/{id}': {
+        put: {
+          operationId: 'Noun_CreateOrReplace',
+          responses: {
+            200: {
+              description: 'Ok',
+            },
+          },
+        },
+      },
+      // 6: should not have update
+      '/test6/{id}': {
+        put: {
+          operationId: 'Noun_CreateOrUpdate',
+          responses: {
+            200: {
+              description: 'Ok',
+            },
+            201: {
+              description: 'Created',
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results).toHaveLength(8);
+    expect(results[0].path.join('.')).toBe('paths./test1/{id}.put.operationId');
+    expect(results[0].message).toBe('OperationId should be of the form "Noun_Verb"');
+    expect(results[1].path.join('.')).toBe('paths./test1/{id}.put.operationId');
+    expect(results[1].message).toBe('OperationId for put with 200 and 201 responses should contain "create" and "replace"');
+    expect(results[2].path.join('.')).toBe('paths./test2/{id}.put.operationId');
+    expect(results[2].message).toBe('OperationId for put with 201 response should contain "create"');
+    expect(results[3].path.join('.')).toBe('paths./test3/{id}.put.operationId');
+    expect(results[3].message).toBe('OperationId for put without 200 response should not contain "replace"');
+    expect(results[4].path.join('.')).toBe('paths./test4/{id}.put.operationId');
+    expect(results[4].message).toBe('OperationId for put with 200 response should contain "replace"');
+    expect(results[5].path.join('.')).toBe('paths./test5/{id}.put.operationId');
+    expect(results[5].message).toBe('OperationId for put without 201 response should not contain "create"');
+    expect(results[6].path.join('.')).toBe('paths./test6/{id}.put.operationId');
+    expect(results[6].message).toBe('OperationId for put with 200 and 201 responses should contain "create" and "replace"');
+    expect(results[7].path.join('.')).toBe('paths./test6/{id}.put.operationId');
+    expect(results[7].message).toContain('OperationId for put should not contain');
+  });
+});
+
+test('az-operation-id should find operationId for patch without standard verb', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1/{id}': {
+        patch: {
+          operationId: 'CreateNoun',
+          responses: {
+            200: {
+              description: 'Success',
+            },
+            201: {
+              description: 'Created',
+            },
+          },
+        },
+      },
+      '/test2/{id}': {
+        patch: {
+          operationId: 'Noun_Submit',
+          responses: {
+            201: {
+              description: 'Created',
+            },
+          },
+        },
+      },
+      '/test3/{id}': {
+        patch: {
+          operationId: 'Noun_CreateOrUpdate',
+          responses: {
+            201: {
+              description: 'Created',
+            },
+          },
+        },
+      },
+      // 4: should have update
+      '/test4/{id}': {
+        patch: {
+          operationId: 'Noun_Swizzle',
+          responses: {
+            200: {
+              description: 'Ok',
+            },
+          },
+        },
+      },
+      // 5: should not have create
+      '/test5/{id}': {
+        patch: {
+          operationId: 'Noun_CreateOrUpdate',
+          responses: {
+            200: {
+              description: 'Ok',
+            },
+          },
+        },
+      },
+      // 6: should not have update
+      '/test6/{id}': {
+        patch: {
+          operationId: 'Noun_CreateOrUpdate',
+          responses: {
+            200: {
+              description: 'Ok',
+            },
+            201: {
+              description: 'Created',
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results).toHaveLength(6);
+    expect(results[0].path.join('.')).toBe('paths./test1/{id}.patch.operationId');
+    expect(results[0].message).toBe('OperationId should be of the form "Noun_Verb"');
+    expect(results[1].path.join('.')).toBe('paths./test1/{id}.patch.operationId');
+    expect(results[1].message).toBe('OperationId for patch with 200 and 201 responses should contain "create" and "update"');
+    expect(results[2].path.join('.')).toBe('paths./test2/{id}.patch.operationId');
+    expect(results[2].message).toBe('OperationId for patch with 201 response should contain "create"');
+    expect(results[3].path.join('.')).toBe('paths./test3/{id}.patch.operationId');
+    expect(results[3].message).toBe('OperationId for patch without 200 response should not contain "update"');
+    expect(results[4].path.join('.')).toBe('paths./test4/{id}.patch.operationId');
+    expect(results[4].message).toBe('OperationId for patch with 200 response should contain "update"');
+    expect(results[5].path.join('.')).toBe('paths./test5/{id}.patch.operationId');
+    expect(results[5].message).toBe('OperationId for patch without 201 response should not contain "create"');
+  });
+});
+
+test('az-operation-id should find operationId for delete without standard verb', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1/{id}': {
+        delete: {
+          operationId: 'Noun_WhackIt',
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results).toHaveLength(1);
+    expect(results[0].path.join('.')).toBe('paths./test1/{id}.delete.operationId');
+    expect(results[0].message).toBe('OperationId for delete should contain "delete"');
+  });
+});
+
+test('az-operation-id should find anti-patterns in put, patch, and post operations', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1/{id}': {
+        put: {
+          operationId: 'Noun_PutTheThing',
+        },
+        patch: {
+          operationId: 'Noun_patch',
+        },
+        post: {
+          operationId: 'Noun_PostSearch',
+        },
+      },
     },
   };
   return linter.run(oasDoc).then((results) => {
     expect(results).toHaveLength(3);
-    expect(results[0].path.join('.')).toBe('paths./api/test3.get.operationId');
-    expect(results[0].message).toBe('OperationId for get method on a collection should contain "List"');
-    expect(results[1].path.join('.')).toBe('paths./api/test3.put.operationId');
-    expect(results[1].message).toBe('OperationId for put method should contain both "Create" and "Update"');
-    expect(results[2].path.join('.')).toBe('paths./api/test3.patch.operationId');
-    expect(results[2].message).toBe('OperationId for patch method should contain both "Create" and "Update"');
+    expect(results[0].path.join('.')).toBe('paths./test1/{id}.put.operationId');
+    expect(results[0].message).toBe('OperationId for put should not contain "Put"');
+    expect(results[1].path.join('.')).toBe('paths./test1/{id}.patch.operationId');
+    expect(results[1].message).toBe('OperationId for patch should not contain "patch"');
+    expect(results[2].path.join('.')).toBe('paths./test1/{id}.post.operationId');
+    expect(results[2].message).toBe('OperationId for post should not contain "Post"');
   });
 });
 
@@ -115,12 +305,12 @@ test('az-operation-id should find no errors', () => {
   const oasDoc = {
     swagger: '2.0',
     paths: {
-      '/api/test3': {
+      '/test/{id}': {
         get: {
           operationId: 'Noun_Get',
         },
         put: {
-          operationId: 'Noun_Create',
+          operationId: 'Noun_Replace',
         },
         patch: {
           operationId: 'Noun_Update',
@@ -132,15 +322,12 @@ test('az-operation-id should find no errors', () => {
           operationId: 'Noun_Anything',
         },
       },
-      '/api/test4': {
+      '/test': {
         get: {
           operationId: 'Noun_List',
-          'x-ms-pageable': {
-            nextLinkName: 'nextLink',
-          },
         },
         put: {
-          operationId: 'Noun_CreateOrUpdate',
+          operationId: 'Noun_CreateOrReplace',
           responses: {
             200: {
               description: 'Success',
@@ -162,12 +349,12 @@ test('az-operation-id should find no errors', () => {
           },
         },
       },
-      '/api/test5': {
+      '/test5/{id}': {
         get: {
           operationId: 'noun_get',
         },
         put: {
-          operationId: 'noun_create',
+          operationId: 'noun_replace',
         },
         patch: {
           operationId: 'noun_update',
@@ -176,9 +363,12 @@ test('az-operation-id should find no errors', () => {
           operationId: 'noun_delete',
         },
       },
-      '/api/test6': {
+      '/test6': {
+        get: {
+          // no operationId
+        },
         put: {
-          operationId: 'noun_update',
+          operationId: 'noun_replace',
           200: {
             description: 'Success',
           },


### PR DESCRIPTION
This PR is a significant revamp of the az-operation-id checks.

The new logic uses the status codes to determine which verbs should and should not appear for put and patch. The logic for get was changed to use the final path segment to determine whether the verb should be "get" or "list".

Tests and docs are all updated.