### PR TITLE
Split error-code-response-header into its own rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -47,6 +47,10 @@ All operations should have a default (error) response.
 
 A delete operation should have a 204 response.
 
+### az-error-code-response-header
+
+All error responses should specify an `x-ms-error-code` response header.
+
 ### az-error-response
 
 Error response body should conform to Azure API Guidelines.

--- a/functions/error-response.js
+++ b/functions/error-response.js
@@ -5,7 +5,6 @@
  * - For all error responses, validate that:
  *   - the response contains a schema for the response body
  *   - the response body schema conforms to Azure API guidelines
- *   - the response headers contain an `x-ms-error-code` header definition
  * - All 4xx or 5xx responses contain x-ms-error-response: true
  */
 
@@ -148,14 +147,6 @@ function validateErrorResponse(errorResponse, responsePath) {
     errors.push(
       ...validateErrorResponseSchema(errorResponse.schema, [...responsePath, 'schema']),
     );
-  }
-
-  // The error response should contain a x-ms-error-code header
-  if (!errorResponse.headers || !errorResponse.headers['x-ms-error-code']) {
-    errors.push({
-      message: 'Error response should contain a x-ms-error-code header.',
-      path: !errorResponse.headers ? responsePath : [...responsePath, 'headers'],
-    });
   }
 
   return errors;

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -90,6 +90,24 @@ rules:
     then:
       function: delete-204-response
 
+  az-error-code-response-header:
+    description: Error response should contain a x-ms-error-code header.
+    severity: warn
+    formats: ['oas2']
+    given:
+    - $.paths[*][*].responses[?(@property >= 400)]
+    - $.paths[*][*].responses["default"]
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          required: ['headers']
+          properties:
+            headers:
+              type: object
+              required: ["x-ms-error-code"]
+
   az-error-response:
     description: Error response body should conform to Microsoft Azure API Guidelines.
     message: '{{error}}'
@@ -186,7 +204,7 @@ rules:
     - $.paths.*[get,put,post,patch,delete,options,head]
     then:
       function: operation-id
-  
+
   az-operation-security:
     description: Operation should have a security requirement or globally.
     message: Operation should have a security requirement.
@@ -464,7 +482,7 @@ rules:
     message: Security definition should have a description.
     severity: warn
     formats: ['oas2', 'oas3']
-    given: 
+    given:
     - $.securityDefinitions[*]
     - $.components.securitySchemes[*]
     then:

--- a/test/error-code-response-header.test.js
+++ b/test/error-code-response-header.test.js
@@ -1,0 +1,89 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-error-code-response-header');
+  return linter;
+});
+
+test('az-error-code-response-header should find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/api/Paths': {
+        get: {
+          responses: {
+            200: {
+              description: 'Success',
+            },
+            // Error response should contain a x-ms-error-code header.
+            400: {
+              description: 'Bad request',
+              schema: {
+                type: 'string',
+              },
+            },
+            default: {
+              description: 'Precondition Failed',
+              schema: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2);
+    // For some reason the paths have "schema" appended to them here,
+    // but not when run in VSCode or the CLI.
+    expect(results[0].path.join('.')).toBe('paths./api/Paths.get.responses.400');
+    expect(results[0].message).toBe('Error response should contain a x-ms-error-code header.');
+    expect(results[1].path.join('.')).toBe('paths./api/Paths.get.responses.default');
+    expect(results[1].message).toBe('Error response should contain a x-ms-error-code header.');
+  });
+});
+
+test('az-error-response should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/api/Paths': {
+        get: {
+          responses: {
+            200: {
+              description: 'Success',
+            },
+            400: {
+              description: 'Bad request',
+              headers: {
+                'x-ms-error-code': {
+                  type: 'string',
+                },
+              },
+              schema: {
+                type: 'string',
+              },
+            },
+            default: {
+              description: 'Bad request',
+              headers: {
+                'x-ms-error-code': {
+                  type: 'string',
+                },
+              },
+              schema: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/error-response.test.js
+++ b/test/error-response.test.js
@@ -17,23 +17,18 @@ test('az-error-response should find errors', () => {
             200: {
               description: 'Success',
             },
-            // Error response should contain a x-ms-error-code header.
-            // Error response schema must be an object schema.
+            // 0: Error response should contain x-ms-error-response
+            // 1: Error response schema must be an object schema.
             400: {
               description: 'Bad request',
               schema: {
                 type: 'string',
               },
             },
-            // Error response should contain x-ms-error-response.
-            // Error response schema should contain an object property named `error`.
+            // 2: Error response should contain x-ms-error-response.
+            // 3: Error response schema should contain an object property named `error`.
             401: {
               description: 'Unauthorized',
-              headers: {
-                'x-ms-error-code': {
-                  type: 'string',
-                },
-              },
               schema: {
                 properties: {
                   code: {
@@ -42,15 +37,10 @@ test('az-error-response should find errors', () => {
                 },
               },
             },
-            // The `error` property in the error response schema should be required.
-            // Error schema should define `code` and `message` properties as required.
+            // 4: The `error` property in the error response schema should be required.
+            // 5: Error schema should define `code` and `message` properties as required.
             403: {
               description: 'Forbidden',
-              headers: {
-                'x-ms-error-code': {
-                  type: 'string',
-                },
-              },
               schema: {
                 properties: {
                   error: {
@@ -68,16 +58,11 @@ test('az-error-response should find errors', () => {
               },
               'x-ms-error-response': true,
             },
-            // Error schema should contain `code` property.
-            // The `message` property of error schema should be type `string`.
-            // Error schema should define `code` property as required.
+            // 6: Error schema should contain `code` property.
+            // 7: The `message` property of error schema should be type `string`.
+            // 8: Error schema should define `code` property as required.
             409: {
               description: 'Conflict',
-              headers: {
-                'x-ms-error-code': {
-                  type: 'string',
-                },
-              },
               schema: {
                 properties: {
                   error: {
@@ -94,16 +79,11 @@ test('az-error-response should find errors', () => {
               },
               'x-ms-error-response': true,
             },
-            // Error schema should contain `message` property.
-            // The `code` property of error schema should be type `string`.
-            // Error schema should define `message` property as required.
+            // 9: Error schema should contain `message` property.
+            // 10: The `code` property of error schema should be type `string`.
+            // 11: Error schema should define `message` property as required.
             412: {
               description: 'Precondition Failed',
-              headers: {
-                'x-ms-error-code': {
-                  type: 'string',
-                },
-              },
               schema: {
                 properties: {
                   error: {
@@ -126,33 +106,31 @@ test('az-error-response should find errors', () => {
     },
   };
   return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(13);
+    expect(results.length).toBe(12);
     expect(results[0].path.join('.')).toBe('paths./api/Paths.get.responses.400');
-    expect(results[0].message).toBe('Error response should contain a x-ms-error-code header.');
-    expect(results[1].path.join('.')).toBe('paths./api/Paths.get.responses.400');
-    expect(results[1].message).toBe('Error response should contain x-ms-error-response.');
-    expect(results[2].path.join('.')).toBe('paths./api/Paths.get.responses.400.schema');
-    expect(results[2].message).toBe('Error response schema must be an object schema.');
-    expect(results[3].path.join('.')).toBe('paths./api/Paths.get.responses.401');
-    expect(results[3].message).toBe('Error response should contain x-ms-error-response.');
-    expect(results[4].path.join('.')).toBe('paths./api/Paths.get.responses.401.schema.properties');
-    expect(results[4].message).toBe('Error response schema should contain an object property named `error`.');
-    expect(results[5].path.join('.')).toBe('paths./api/Paths.get.responses.403.schema');
-    expect(results[5].message).toBe('The `error` property in the error response schema should be required.');
-    expect(results[6].path.join('.')).toBe('paths./api/Paths.get.responses.403.schema.properties.error');
-    expect(results[6].message).toBe('Error schema should define `code` and `message` properties as required.');
-    expect(results[7].path.join('.')).toBe('paths./api/Paths.get.responses.409.schema.properties.error.properties');
-    expect(results[7].message).toBe('Error schema should contain `code` property.');
-    expect(results[8].path.join('.')).toBe('paths./api/Paths.get.responses.409.schema.properties.error.properties.message');
-    expect(results[8].message).toBe('The `message` property of error schema should be type `string`.');
-    expect(results[9].path.join('.')).toBe('paths./api/Paths.get.responses.409.schema.properties.error.required');
-    expect(results[9].message).toBe('Error schema should define `code` property as required.');
-    expect(results[10].path.join('.')).toBe('paths./api/Paths.get.responses.412.schema.properties.error.properties');
-    expect(results[10].message).toBe('Error schema should contain `message` property.');
-    expect(results[11].path.join('.')).toBe('paths./api/Paths.get.responses.412.schema.properties.error.properties.code.type');
-    expect(results[11].message).toBe('The `code` property of error schema should be type `string`.');
-    expect(results[12].path.join('.')).toBe('paths./api/Paths.get.responses.412.schema.properties.error.required');
-    expect(results[12].message).toBe('Error schema should define `message` property as required.');
+    expect(results[0].message).toBe('Error response should contain x-ms-error-response.');
+    expect(results[1].path.join('.')).toBe('paths./api/Paths.get.responses.400.schema');
+    expect(results[1].message).toBe('Error response schema must be an object schema.');
+    expect(results[2].path.join('.')).toBe('paths./api/Paths.get.responses.401');
+    expect(results[2].message).toBe('Error response should contain x-ms-error-response.');
+    expect(results[3].path.join('.')).toBe('paths./api/Paths.get.responses.401.schema.properties');
+    expect(results[3].message).toBe('Error response schema should contain an object property named `error`.');
+    expect(results[4].path.join('.')).toBe('paths./api/Paths.get.responses.403.schema');
+    expect(results[4].message).toBe('The `error` property in the error response schema should be required.');
+    expect(results[5].path.join('.')).toBe('paths./api/Paths.get.responses.403.schema.properties.error');
+    expect(results[5].message).toBe('Error schema should define `code` and `message` properties as required.');
+    expect(results[6].path.join('.')).toBe('paths./api/Paths.get.responses.409.schema.properties.error.properties');
+    expect(results[6].message).toBe('Error schema should contain `code` property.');
+    expect(results[7].path.join('.')).toBe('paths./api/Paths.get.responses.409.schema.properties.error.properties.message');
+    expect(results[7].message).toBe('The `message` property of error schema should be type `string`.');
+    expect(results[8].path.join('.')).toBe('paths./api/Paths.get.responses.409.schema.properties.error.required');
+    expect(results[8].message).toBe('Error schema should define `code` property as required.');
+    expect(results[9].path.join('.')).toBe('paths./api/Paths.get.responses.412.schema.properties.error.properties');
+    expect(results[9].message).toBe('Error schema should contain `message` property.');
+    expect(results[10].path.join('.')).toBe('paths./api/Paths.get.responses.412.schema.properties.error.properties.code.type');
+    expect(results[10].message).toBe('The `code` property of error schema should be type `string`.');
+    expect(results[11].path.join('.')).toBe('paths./api/Paths.get.responses.412.schema.properties.error.required');
+    expect(results[11].message).toBe('Error schema should define `message` property as required.');
   });
 });
 
@@ -168,11 +146,6 @@ test('az-error-response should find no errors', () => {
             },
             400: {
               description: 'Bad request',
-              headers: {
-                'x-ms-error-code': {
-                  type: 'string',
-                },
-              },
               schema: {
                 type: 'object',
                 properties: {


### PR DESCRIPTION
This PR moves the check for the x-ms-error-code response header out of az-error-response to a new rule, az-error-code-response-header.

This change will allow users to selectively disable the az-error-code-response-header check without disabling all checking on the error response.