### PR TITLE
Add az-ms-enum-descriptions rule to check for descriptions on enums

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -90,6 +90,11 @@ A 202 response should include an Operation-Location response header.
 
 The use of the autorest `x-ms-client-flatten` extension is discouraged.
 
+### az-ms-enum-descriptions
+
+Include descriptions for all values in the `x-ms-enum` extension.
+See the [`x-ms-enum` documentation](https://github.com/Azure/autorest/tree/main/docs/extensions#x-ms-enum) for more information.
+
 ### az-ms-paths
 
 Don't use the Autorest `x-ms-paths` extension except where necessary to support legacy APIs.

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -161,6 +161,24 @@ rules:
     then:
       function: undefined
 
+  az-ms-enum-descriptions:
+    description: Include descriptions for all values in the x-ms-enum extension.
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given: $..x-ms-enum
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          properties:
+            values:
+              type: array
+              items:
+                type: object
+                required: ['value', 'description']
+          required: ['values']
+
   az-ms-paths:
     description: Don't use x-ms-paths except where necessary to support legacy APIs.
     severity: warn


### PR DESCRIPTION
This PR adds a simple rule to check that all values in an x-ms-enum extension have a "description".  This will improve the quality of the generated REST API docs.