### PR TITLE
Add az-patch-path rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -179,6 +179,12 @@ The request body content type for patch operations should be JSON merge patch.
 
 Only patch operations should accept JSON merge patch.
 
+### az-patch-path
+
+Patch operations are typically issued on a specific resource whose id is the final segment of the path.
+Therefore, it is uncommon for a patch operation to be defined on a path that does not have a path parameter
+as the final path segment.
+
 ### az-path-characters
 
 Service-defined path segments should be restricted to 0-9 A-Z a-z - . _ ~, with : allowed only as described below to designate an action operation.
@@ -206,8 +212,9 @@ Property names should be lowerCamelCase.
 
 ### az-put-path
 
-The path for a put operation should have a path parameter as the final path segment.
-This path parameter is the identifier of the resource to create or update.
+Put operations are typically issued on a specific resource whose id is the final segment of the path.
+Therefore, it is uncommon for a put operation to be defined on a path that does not have a path parameter
+as the final path segment.
 
 ### az-request-body-not-allowed
 

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -329,15 +329,6 @@ rules:
     then:
       function: param-order
 
-  az-path-parameter-names:
-    description: Path parameter names should be consistent across all paths.
-    message: '{{error}}'
-    severity: warn
-    formats: ['oas2', 'oas3']
-    given: $.paths
-    then:
-      function: path-param-names
-
   # Patch request body content type should be application/merge-patch+json
   az-patch-content-type:
     description: The request body content type for patch operations should be JSON merge patch.
@@ -347,6 +338,17 @@ rules:
     given: $
     then:
       function: patch-content-type
+
+  # Patch on a path that does not end in path parameter is uncommon.
+  az-patch-path:
+    description: Patch on a path that does not end with a path parameter is uncommon.
+    severity: info
+    formats: ['oas2', 'oas3']
+    given: $.paths[*].patch^~
+    then:
+      function: pattern
+      functionOptions:
+        match: '/\}$/'
 
   # Static path segments should be kebab-case
   az-path-case-convention:
@@ -375,6 +377,15 @@ rules:
         # Check each path segment individually and ignore param segments
         # Note: the ':' is only allowed in the final path segment
         match: '^(\/([0-9A-Za-z._~-]+|{[^}]+}))*\/([0-9A-Za-z._~-]+|{[^}]*})?(:[0-9A-Za-z._~-]+)?$'
+
+  az-path-parameter-names:
+    description: Path parameter names should be consistent across all paths.
+    message: '{{error}}'
+    severity: warn
+    formats: ['oas2', 'oas3']
+    given: $.paths
+    then:
+      function: path-param-names
 
   az-path-parameter-schema:
     description: 'Path parameter should be type: string and specify maxLength and pattern.'
@@ -432,9 +443,8 @@ rules:
       function: truthy
 
   az-put-path:
-    description: The path for a put should have a final path parameter.
-    message: The path for a put should have a final path parameter.
-    severity: warn
+    description: Put on a path that does not end with a path parameter is uncommon.
+    severity: info
     formats: ['oas2', 'oas3']
     given: $.paths[*].put^~
     then:


### PR DESCRIPTION
This PR adds a simple rule to check that the final path segment of the path for a patch operation is a path parameter.

There is already a similar rule that checks put operations.

I made both of these rules "info" since there are legitimate cases for put or patch on a path that does not end in a path parameter.

I expanded the documentation a bit to explain the motivation of these two rules.