### PR TITLE
No msg for missing error response schema for head request

### DIFF
--- a/functions/error-response.js
+++ b/functions/error-response.js
@@ -140,10 +140,13 @@ function validateErrorResponse(errorResponse, responsePath) {
 
   // The error response schema should conform to Microsoft API Guidelines
   if (!errorResponse.schema) {
-    errors.push({
-      message: 'Error response should have a schema.',
-      path: responsePath,
-    });
+    const method = responsePath[responsePath.length - 3];
+    if (method !== 'head') {
+      errors.push({
+        message: 'Error response should have a schema.',
+        path: responsePath,
+      });
+    }
   } else {
     errors.push(
       ...validateErrorResponseSchema(errorResponse.schema, [...responsePath, 'schema']),

--- a/test/error-response.test.js
+++ b/test/error-response.test.js
@@ -156,6 +156,34 @@ test('az-error-response should find errors', () => {
   });
 });
 
+test('az-error-response should not flag missing schema in error response for head method', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/api/Paths': {
+        head: {
+          responses: {
+            200: {
+              description: 'Success',
+            },
+            default: {
+              description: 'Error',
+              headers: {
+                'x-ms-error-code': {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});
+
 test('az-error-response should find no errors', () => {
   const oasDoc = {
     swagger: '2.0',


### PR DESCRIPTION
This PR skips the message for missing error response schema for head operations.