### PR TITLE
Back out check for unique path segment for path param name

### DIFF
--- a/functions/path-param-names.js
+++ b/functions/path-param-names.js
@@ -1,7 +1,6 @@
 // Check that path parameter names are consistent across all paths.
 // Specifically:
 // - The path parameter that follows a static path segment must be the same across all paths
-// - The static path segment that precedes a path parameter must be the same across all paths
 
 // `given` is the paths object
 module.exports = (paths) => {
@@ -13,8 +12,6 @@ module.exports = (paths) => {
 
   // Dict to accumulate the parameter name associated with a path segment
   const paramNameForSegment = {};
-  // Dict to accumulate the segment name associated with a path parameter
-  const segmentForParamName = {};
 
   // Identify inconsistent names by iterating over all paths and building up a
   // dictionary that maps a static path segment to the path parameter that
@@ -40,16 +37,6 @@ module.exports = (paths) => {
           }
         } else {
           paramNameForSegment[p] = param;
-        }
-        if (segmentForParamName[param]) {
-          if (segmentForParamName[param] !== p) {
-            errors.push({
-              message: `Inconsistent path segments "${segmentForParamName[param]}" and "${p}" for parameter "${param}".`,
-              path: ['paths', pathKey],
-            });
-          }
-        } else {
-          segmentForParamName[param] = p;
         }
       }
     });

--- a/test/path-param-names.test.js
+++ b/test/path-param-names.test.js
@@ -25,24 +25,6 @@ test('az-path-parameter-names should find errors', () => {
   });
 });
 
-test('az-path-parameter-names should find a static path segment that is followed by two different path params', () => {
-  const oasDoc = {
-    swagger: '2.0',
-    paths: {
-      '/foo/{p1}': {},
-      '/bar/{p1}/baz/{p2}': {},
-      '/qux/{p2}': {},
-    },
-  };
-  return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(2);
-    expect(results[0].path.join('.')).toBe('paths./bar/{p1}/baz/{p2}');
-    expect(results[0].message).toContain('Inconsistent path segments "foo" and "bar" for parameter "p1"');
-    expect(results[1].path.join('.')).toBe('paths./qux/{p2}');
-    expect(results[1].message).toContain('Inconsistent path segments "baz" and "qux" for parameter "p2"');
-  });
-});
-
 test('az-path-parameter-names should find no errors', () => {
   const oasDoc = {
     swagger: '2.0',


### PR DESCRIPTION
This PR backs out the change made in #83 that flags any path parameter name that is used for more than one path segment. This rule was over-zealous and fires when multiple resources use a common name like "id" as the path parameter name.