### PR TITLE
Add az-readonly-in-response-schema rule with test and docs

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -196,6 +196,10 @@ Property names should be lowerCamelCase.
 The path for a put operation should have a path parameter as the final path segment.
 This path parameter is the identifier of the resource to create or update.
 
+### az-readonly-in-response-schema
+
+Don't mark properties as `readOnly: true` in schemas that are only used within response bodies.
+
 ### az-request-body-not-allowed
 
 A get or delete operation must not accept a request body/body parameter.

--- a/functions/readonly-in-response-schema.js
+++ b/functions/readonly-in-response-schema.js
@@ -1,0 +1,122 @@
+// Flag any properties that are readonly in the response schema.
+
+// Scan an OpenAPI document to determine if a schema is a response-only schema,
+// which means it is not references by any request schemas.
+// Any schema that is referenced by a request is considered a request schema.
+// Any schema referenced by a request schema is also considered a request schema.
+// Any schema that is not a request schema is considered a response-only schema.
+
+let requestSchemas;
+
+function getRequestSchemas(oasDoc) {
+  /* eslint-disable object-curly-newline,object-curly-spacing */
+  const getOps = ({put, post, patch}) => [put, post, patch];
+  const topLevelRequestSchemas = Object.values(oasDoc.paths || {})
+    .flatMap(getOps).filter(Boolean)
+    .flatMap(({parameters}) => parameters.filter(({in: location}) => location === 'body'))
+    .flatMap(({schema}) => (schema ? [schema] : []))
+    .filter(({$ref}) => $ref && $ref.match(/^#\/definitions\//))
+    .map(({$ref}) => $ref.replace(/^#\/definitions\//, ''));
+  /* eslint-enable object-curly-newline,object-curly-spacing */
+
+  requestSchemas = new Set();
+
+  // Now that we have the top-level response schemas, we need to find all the
+  // schemas that are referenced by those schemas. We do this by iterating
+  // over the schemas until we find no new schemas to add to the set.
+  const schemasToProcess = [...topLevelRequestSchemas];
+  while (schemasToProcess.length > 0) {
+    const schemaName = schemasToProcess.pop();
+    requestSchemas.add(schemaName);
+    const schema = oasDoc.definitions[schemaName];
+    if (schema) {
+      if (schema.properties) {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const property of Object.values(schema.properties)) {
+          if (property.$ref && property.$ref.match(/^#\/definitions\//)) {
+            const ref = property.$ref.replace(/^#\/definitions\//, '');
+            if (!requestSchemas.has(ref) && !schemasToProcess.includes(ref)) {
+              schemasToProcess.push(ref);
+            }
+          }
+          if (property.items && property.items.$ref && property.items.$ref.match(/^#\/definitions\//)) {
+            const ref = property.items.$ref.replace(/^#\/definitions\//, '');
+            if (!requestSchemas.has(ref) && !schemasToProcess.includes(ref)) {
+              schemasToProcess.push(ref);
+            }
+          }
+          if (property.additionalProperties && property.additionalProperties.$ref && property.additionalProperties.$ref.match(/^#\/definitions\//)) {
+            const ref = property.additionalProperties.$ref.replace(/^#\/definitions\//, '');
+            if (!requestSchemas.has(ref) && !schemasToProcess.includes(ref)) {
+              schemasToProcess.push(ref);
+            }
+          }
+        }
+      }
+      if (schema.allOf) {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const element of schema.allOf) {
+          if (element.$ref && element.$ref.match(/^#\/definitions\//)) {
+            const ref = element.$ref.replace(/^#\/definitions\//, '');
+            if (!requestSchemas.has(ref) && !schemasToProcess.includes(ref)) {
+              schemasToProcess.push(ref);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// compute a hash for a string
+function hashCode(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    /* eslint-disable no-bitwise */
+    hash = ((hash << 5) - hash) + str.charCodeAt(i);
+    hash |= 0; // Convert to 32bit integer
+    /* eslint-enable no-bitwise */
+  }
+  return hash;
+}
+
+let docHash;
+
+function responseOnlySchema(schemaName, oasDoc) {
+  const thisDocHash = hashCode(JSON.stringify(oasDoc));
+  if (!requestSchemas || docHash !== thisDocHash) {
+    getRequestSchemas(oasDoc);
+    docHash = thisDocHash;
+  }
+
+  if (requestSchemas.has(schemaName)) {
+    return false;
+  }
+
+  return true;
+}
+
+// `schema` is a (resolved) parameter entry at the path or operation level
+module.exports = (schema, _opts, context) => {
+  const schemaName = context.path[context.path.length - 1];
+  const oasDoc = context.document.data;
+  if (!responseOnlySchema(schemaName, oasDoc)) {
+    return [];
+  }
+
+  // Flag any properties that are readonly in the response schema.
+
+  const errors = [];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const [propertyName, property] of Object.entries(schema.properties || {})) {
+    if (property.readOnly) {
+      errors.push({
+        message: 'Property of response-only schema should not be marked readOnly',
+        path: [...context.path, 'properties', propertyName, 'readOnly'],
+      });
+    }
+  }
+
+  return errors;
+};

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -15,6 +15,7 @@ functions:
   - patch-content-type
   - path-param-schema
   - path-param-names
+  - readonly-in-response-schema
   - security-definitions
   - security-requirements
   - schema-type-and-format
@@ -425,6 +426,14 @@ rules:
       function: pattern
       functionOptions:
         notMatch: '/^array$/'
+
+  az-readonly-in-response-schema:
+    description: Properties in response-only schemas should not be marked as readOnly true
+    severity: warn
+    formats: ['oas2']
+    given: $.definitions[*]
+    then:
+      function: readonly-in-response-schema
 
   az-schema-description-or-title:
     description: All schemas should have a description or title.

--- a/test/readonly-in-response-schema.test.js
+++ b/test/readonly-in-response-schema.test.js
@@ -1,0 +1,163 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-readonly-in-response-schema');
+  return linter;
+});
+
+test('az-readonly-in-response-schema should find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        post: {
+          parameters: [
+            {
+              in: 'body',
+              name: 'body',
+              schema: {
+                $ref: '#/definitions/Model1',
+              },
+            },
+          ],
+          responses: {
+            200: {
+              description: 'Success',
+              schema: {
+                $ref: '#/definitions/Model2',
+              },
+            },
+          },
+        },
+      },
+    },
+    definitions: {
+      Model1: {
+        type: 'object',
+        allOf: [
+          {
+            $ref: '#/definitions/Model3',
+          },
+        ],
+      },
+      Model2: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            readOnly: true,
+          },
+        },
+      },
+      Model3: {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+            readOnly: true,
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    expect(results[0].path.join('.')).toBe('definitions.Model2.properties.id.readOnly');
+  });
+});
+
+test('az-readonly-in-response-schema should not find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        post: {
+          parameters: [
+            {
+              in: 'body',
+              name: 'body',
+              schema: {
+                $ref: '#/definitions/Model1',
+              },
+            },
+          ],
+          responses: {
+            200: {
+              description: 'Success',
+              schema: {
+                $ref: '#/definitions/Model2',
+              },
+            },
+          },
+        },
+      },
+    },
+    definitions: {
+      Model1: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            readOnly: true,
+          },
+          things: {
+            type: 'array',
+            items: {
+              $ref: '#/definitions/Thing',
+            },
+          },
+          tags: {
+            additionalProperties: {
+              $ref: '#/definitions/Tag',
+            },
+          },
+        },
+        allOf: [
+          {
+            $ref: '#/definitions/Model3',
+          },
+        ],
+      },
+      Model2: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+        },
+      },
+      Model3: {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+            readOnly: true,
+          },
+        },
+      },
+      Thing: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            readOnly: true,
+          },
+        },
+      },
+      Tag: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            readOnly: true,
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR adds a rule to check for properties that are marked `readOnly: true` in schemas that are never used in a request body.