### PR TITLE
Minor fix to az-property-type to avoid false positives

### DIFF
--- a/spectral.yaml
+++ b/spectral.yaml
@@ -426,7 +426,8 @@ rules:
     message: Property should have a defined type.
     severity: warn
     resolved: false
-    given: $..properties[?(@object() && @.$ref == undefined)]
+    # Exclude properties that contains allOf to avoid false positives.
+    given: $..properties[?(@object() && @.$ref == undefined && @.allOf == undefined)]
     then:
       field: type
       function: truthy


### PR DESCRIPTION
This PR is a minor fix to az-property-type that excludes properties that contain `allOf` to avoid a false positive when the `allOf` contains a $ref to a schema that has a defined type (a common situation).