### PR TITLE
Update for new LRO guidelines

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -45,7 +45,7 @@ All operations should have a default (error) response.
 
 ### az-delete-204-response
 
-A delete operation should have a 204 response.
+A (non-long-running) delete operation should have a 204 response.
 
 ### az-error-code-response-header
 
@@ -86,9 +86,29 @@ explicitly states that these header definitions should be ignored.
 
 Operations with a 202 response should specify `x-ms-long-running-operation: true`.
 
-### az-lro-headers
+### az-lro-get-not-allowed
+
+Get operations should not be long-running.
+
+### az-lro-patch-not-allowed
+
+Patch operations should not be long-running.
+
+### az-lro-put-response-codes
+
+A long-running PUT operation should not return a 202 response.
+
+### az-lro-response-codes
+
+An operation that returns 202 should not return other 2XX responses.
+
+### az-lro-response-headers
 
 A 202 response should include an Operation-Location response header.
+
+### az-lro-response-schema
+
+A 202 response should have a response body that contains a representation of the "status monitor" -- the same schema that is returned from GET on the Operation-Location.
 
 ### az-ms-client-flatten
 
@@ -318,11 +338,7 @@ array of scope names, each of which must also be defined in the referenced secur
 
 ### az-success-response-body
 
-All success responses except 202 and 204 should define a response body.
-
-### az-success-response-nobody
-
-Responses for status codes 202 and 204 should have no response body.
+All success responses except 204 should define a response body.
 
 ### az-top-default-not-allowed
 

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -151,7 +151,48 @@ rules:
       field: x-ms-long-running-operation
       function: truthy
 
-  az-lro-headers:
+  az-lro-get-not-allowed:
+    description: Get operations should not be long-running.
+    severity: warn
+    formats: ['oas2','oas3']
+    given: $.paths[*].get.responses.202
+    then:
+      function: falsy
+
+  az-lro-patch-not-allowed:
+    description: Patch operations should not be long-running.
+    severity: warn
+    formats: ['oas2','oas3']
+    given: $.paths[*].patch.responses.202
+    then:
+      function: falsy
+
+  az-lro-put-response-codes:
+    description: Long-running PUT should not return a 202 response.
+    severity: warn
+    formats: ['oas2','oas3']
+    given: $.paths[*].put.responses.202
+    then:
+      function: falsy
+
+  az-lro-response-codes:
+    description: An operation that returns 202 should not return other 2XX responses.
+    severity: warn
+    formats: ['oas2','oas3']
+    # The responses object of an operation that includes a 202 response
+    # Exclude get, put and patch since the 202 for these will be flagged in other rules
+    given: $.paths[*].[post,delete].responses[?(@property == '202')]^
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          not:
+            anyOf:
+              - required: ['200']
+              - required: ['201']
+              - required: ['204']
+
+  az-lro-response-headers:
     description: A 202 response should include an Operation-Location response header.
     message: A 202 response should include an Operation-Location response header.
     severity: warn
@@ -161,6 +202,16 @@ rules:
       function: has-header
       functionOptions:
         name: Operation-location
+
+  az-lro-response-schema:
+    description: A 202 response should include a schema for the operation status monitor.
+    message: A 202 response should include a schema for the operation status monitor.
+    severity: warn
+    formats: ['oas2']
+    given: $.paths[*][*].responses[?(@property == '202')]
+    then:
+      field: schema
+      function: truthy
 
   az-204-no-response-body:
     description: A 204 response should have no response body.
@@ -574,13 +625,14 @@ rules:
       functionOptions:
         min: 1
 
-  # All success responses except 202 & 204 should define a response body
+  # All success responses except 204 should define a response body
   # ref: https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#1321-put
   az-success-response-body:
-    description: All success responses except 202 & 204 should define a response body.
+    description: All success responses except 204 should define a response body.
     severity: warn
     formats: ['oas2']
     # list http methods explicitly to exclude head
+    # exclude 202 to avoid duplication with az-lro-response-schema rule
     given: $.paths[*][get,put,post,patch,delete].responses[?(@property >= 200 && @property < 300 && @property != '202' && @property != '204')]
     then:
       field: schema

--- a/test/lro-put-response-codes.test.js
+++ b/test/lro-put-response-codes.test.js
@@ -1,0 +1,89 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-lro-put-response-codes');
+  return linter;
+});
+
+test('az-lro-put-response-codes should find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        put: {
+          responses: {
+            202: {
+              description: 'Accepted',
+            },
+          },
+        },
+      },
+      '/test2': {
+        put: {
+          responses: {
+            200: {
+              description: 'Success',
+            },
+            201: {
+              description: 'Created',
+            },
+            202: {
+              description: 'Accepted',
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results).toHaveLength(2);
+    expect(results[0].path.join('.')).toBe('paths./test1.put.responses.202');
+    expect(results[1].path.join('.')).toBe('paths./test2.put.responses.202');
+    results.forEach((result) => expect(result.message).toBe(
+      'Long-running PUT should not return a 202 response.',
+    ));
+  });
+});
+
+test('az-lro-put-response-codes should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        put: {
+          responses: {
+            200: {
+              description: 'Success',
+            },
+            201: {
+              description: 'Created',
+            },
+          },
+        },
+      },
+      '/test2': {
+        put: {
+          responses: {
+            200: {
+              description: 'Success',
+            },
+          },
+        },
+      },
+      '/test3': {
+        put: {
+          responses: {
+            201: {
+              description: 'Created',
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/lro-response-codes.test.js
+++ b/test/lro-response-codes.test.js
@@ -1,0 +1,119 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-lro-response-codes');
+  return linter;
+});
+
+test('az-lro-response-codes should find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        post: {
+          responses: {
+            200: {
+              description: 'Success',
+            },
+            202: {
+              description: 'Accepted',
+            },
+          },
+        },
+      },
+      '/test2': {
+        delete: {
+          responses: {
+            202: {
+              description: 'Accepted',
+            },
+            204: {
+              description: 'No Content',
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results).toHaveLength(2);
+    expect(results[0].path.join('.')).toBe('paths./test1.post.responses');
+    expect(results[1].path.join('.')).toBe('paths./test2.delete.responses');
+    results.forEach((result) => expect(result.message).toBe(
+      'An operation that returns 202 should not return other 2XX responses.',
+    ));
+  });
+});
+
+test('az-lro-response-codes should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1': {
+        post: {
+          responses: {
+            202: {
+              description: 'Accepted',
+            },
+          },
+        },
+      },
+      '/test2': {
+        delete: {
+          responses: {
+            202: {
+              description: 'Accepted',
+            },
+          },
+        },
+      },
+      '/test3': {
+        post: {
+          responses: {
+            202: {
+              description: 'Accepted',
+            },
+            default: {
+              description: 'Error',
+            },
+          },
+        },
+      },
+      '/test4': {
+        delete: {
+          responses: {
+            202: {
+              description: 'Accepted',
+            },
+            default: {
+              description: 'Error',
+            },
+          },
+        },
+      },
+      '/test5': {
+        post: {
+          responses: {
+            200: {
+              description: 'Success',
+            },
+          },
+        },
+      },
+      '/test6': {
+        delete: {
+          responses: {
+            204: {
+              description: 'No Content',
+            },
+          },
+        },
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});

--- a/test/lro-response-headers.test.js
+++ b/test/lro-response-headers.test.js
@@ -3,11 +3,11 @@ const { linterForRule } = require('./utils');
 let linter;
 
 beforeAll(async () => {
-  linter = await linterForRule('az-lro-headers');
+  linter = await linterForRule('az-lro-response-headers');
   return linter;
 });
 
-test('az-lro-headers should find errors', () => {
+test('az-lro-response-headers should find errors', () => {
   const oasDoc = {
     swagger: '2.0',
     paths: {
@@ -46,7 +46,7 @@ test('az-lro-headers should find errors', () => {
   });
 });
 
-test('az-lro-headers should find no errors', () => {
+test('az-lro-response-headers should find no errors', () => {
   const oasDoc = {
     swagger: '2.0',
     paths: {


### PR DESCRIPTION
This PR adds some rules to catch the most common and egregious issues with conformance to the updated Azure LRO guidelines.

- az-lro-get-not-allowed flags long-running gets
- az-lro-patch-not-allowed flags long-running patches
- az-lro-put-response-codes flags a put that returns 202
- az-lro-response-codes flags a long-running operation that also returns other 2XX responses
- az-lro-response-schema flags a 202 response without a schema

Docs updated and (some) tests added.