### PR TITLE
Fix az-security-requirement for scope with empty value

### DIFF
--- a/functions/security-requirements.js
+++ b/functions/security-requirements.js
@@ -53,7 +53,7 @@ module.exports = (input, _, context) => {
             });
           }
           scopes.forEach((scope, scopeIndex) => {
-            if (!scheme.scopes[scope]) {
+            if (!(scope in scheme.scopes)) {
               errors.push({
                 message: `Scope "${scope}" is not defined for security scheme "${key}".`,
                 path: [...path, index, key, scopeIndex],

--- a/test/security-requirements.test.js
+++ b/test/security-requirements.test.js
@@ -274,10 +274,21 @@ test('az-security-requirements should find no errors', () => {
         in: 'header',
         description: 'API Key for your subscription',
       },
+      OAuth2Auth: {
+        type: 'oauth2',
+        flow: 'implicit',
+        authorizationUrl: 'https://example.com/oauth2/v2.0/authorize',
+        scopes: {
+          'https://example.com/.default': '',
+        },
+      },
     },
     security: [
       {
         apim_key: [],
+      },
+      {
+        OAuth2Auth: ['https://example.com/.default'],
       },
     ],
   };


### PR DESCRIPTION
Little fix to az-security-requirement to handle the case where an oauth2 scope is defined but the description is an empty string.