### PR TITLE
Check for polymorphic child schemas in search for request schemas

### DIFF
--- a/test/readonly-in-response-schema.test.js
+++ b/test/readonly-in-response-schema.test.js
@@ -93,6 +93,24 @@ test('az-readonly-in-response-schema should not find errors', () => {
           },
         },
       },
+      '/test2': {
+        post: {
+          parameters: [
+            {
+              in: 'body',
+              name: 'body',
+              schema: {
+                $ref: '#/definitions/Pet',
+              },
+            },
+          ],
+          responses: {
+            200: {
+              description: 'Success',
+            },
+          },
+        },
+      },
     },
     definitions: {
       Model1: {
@@ -150,6 +168,29 @@ test('az-readonly-in-response-schema should not find errors', () => {
         type: 'object',
         properties: {
           id: {
+            type: 'string',
+            readOnly: true,
+          },
+        },
+      },
+      Pet: {
+        discriminator: 'petType',
+      },
+      Dog: {
+        type: 'object',
+        allOf: [{ $ref: '#/definitions/Pet' }],
+        properties: {
+          cute: {
+            type: 'number',
+            readOnly: true,
+          },
+        },
+      },
+      Cat: {
+        type: 'object',
+        allOf: [{ $ref: '#/definitions/Pet' }],
+        properties: {
+          attitude: {
             type: 'string',
             readOnly: true,
           },


### PR DESCRIPTION
This PR adds logic to search for polymorphic children of a request schema when constructing the full set of request schemas in the az-readonly-in-response-schema processing.