### PR TITLE
Add az-request-body-type rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -255,6 +255,10 @@ RFC7231 states that the payload for both get and delete "has no defined semantic
 
 Flag a body parameter/request body that is not marked as required. This is a common oversight.
 
+### az-request-body-type
+
+Request body schema must not be a bare array.
+
 ### az-response-body-type
 
 Response body schema must not be a bare array.

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -547,6 +547,18 @@ rules:
       field: required
       function: truthy
 
+  az-request-body-type:
+    description: Request body schema must not be a bare array.
+    severity: warn
+    formats: ['oas2']
+    given:
+    - $.paths[*].[put,post,patch].parameters.[?(@.in == 'body')].schema
+    then:
+      field: type
+      function: pattern
+      functionOptions:
+        notMatch: '/^array$/'
+
   az-response-body-type:
     description: Response body schema must not be a bare array.
     severity: warn


### PR DESCRIPTION
This PR adds the az-request-body-type rule, which flags any request body whose top-level type is "array".