### PR TITLE
Relax schema name rule to allow optional . separator

### DIFF
--- a/spectral.yaml
+++ b/spectral.yaml
@@ -596,9 +596,10 @@ rules:
     formats: ['oas2']
     given: $.definitions.*~
     then:
-      function: casing
+      # Pascal case with optional "." separator
+      function: pattern
       functionOptions:
-        type: pascal
+        match: '^([A-Z][a-z0-9]+\.?)*[A-Z][a-z0-9]+$'
 
   az-schema-type-and-format:
     description: Schema should use well-defined type and format.


### PR DESCRIPTION
This PR changes the az-schema-names-convention to allow "." characters as separators in schema names. TypeSpec qualifies schema names with the namespace and uses the "." separator, so this avoids flagging all these.