### PR TITLE
Only flag optional request body if required is not specified

### DIFF
--- a/spectral.yaml
+++ b/spectral.yaml
@@ -542,10 +542,10 @@ rules:
     severity: info
     formats: ['oas2']
     given:
-    - $.paths[*].[put,post,patch].parameters.[?(@.in == 'body')]
+    # Don't flag request body if it explicitly specifies required: false
+    - $.paths[*].[put,post,patch].parameters.[?(@.in == 'body' && @.required == undefined)]
     then:
-      field: required
-      function: truthy
+      function: falsy
 
   az-request-body-type:
     description: Request body schema must not be a bare array.

--- a/test/request-body-optional.test.js
+++ b/test/request-body-optional.test.js
@@ -94,6 +94,18 @@ test('az-request-body-optional should find no errors', () => {
           ],
         },
       },
+      '/test4': {
+        post: {
+          parameters: [
+            {
+              name: 'body',
+              in: 'body',
+              type: 'string',
+              required: false,
+            },
+          ],
+        },
+      },
     },
   };
   return linter.run(oasDoc).then((results) => {


### PR DESCRIPTION
Minor update to the az-request-body-optional rule to avoid flagging a request body that explicitly specifies `required: false`.