### PR TITLE
Add az-boolean-names-convention rule

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -33,6 +33,10 @@ of defining api-version as an enum with a single value -- the most current API v
 This requires removing the old API version when a new version is defined,
 which is disallowed by the breaking changes policy.
 
+### az-boolean-names-convention / az-boolean-param-names-convention
+
+Do not use "is" prefix in names of boolean values.
+
 ### az-consistent-response-body
 
 For a path with a "create" operation (put or patch that returns 201), the 200 response of

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -64,6 +64,30 @@ rules:
       field: enum
       function: falsy
 
+  az-boolean-names-convention:
+    description: Do not use "is" prefix in names of boolean values
+    severity: warn
+    resolved: false
+    given:
+    # We don't filter on type, because its complicated and no other types should start with "is" either
+    - $..[?(@.type === 'object' && @.properties)].properties.*~
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: '/^is[A-Z]/'
+
+  az-boolean-param-names-convention:
+    description: Do not use "is" prefix in names of boolean values
+    severity: warn
+    given:
+    # We don't filter on type, because its complicated and no other types should start with "is" either
+    - $.paths[*].parameters.*.name
+    - $.paths.*[get,put,post,patch,delete,options,head].parameters.*.name
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: '/^is[A-Z]/'
+
   az-consistent-response-body:
     description: Ensure the get, put, and patch response body schemas are consistent.
     message: '{{error}}'
@@ -524,6 +548,14 @@ rules:
       functionOptions:
         match: '/\}$/'
 
+  az-readonly-in-response-schema:
+    description: Properties in response-only schemas should not be marked as readOnly true
+    severity: warn
+    formats: ['oas2']
+    given: $.definitions[*]
+    then:
+      function: readonly-in-response-schema
+
   az-request-body-not-allowed:
     description: A get or delete operation must not accept a body parameter.
     severity: error
@@ -569,14 +601,6 @@ rules:
       function: pattern
       functionOptions:
         notMatch: '/^array$/'
-
-  az-readonly-in-response-schema:
-    description: Properties in response-only schemas should not be marked as readOnly true
-    severity: warn
-    formats: ['oas2']
-    given: $.definitions[*]
-    then:
-      function: readonly-in-response-schema
 
   az-schema-description-or-title:
     description: All schemas should have a description or title.


### PR DESCRIPTION
Add the az-boolean-names-convention rule to flag boolean properties that violate the Azure naming guidance:

⛔ DO NOT use "is" prefix in names of boolean values, e.g. "enabled" not "isEnabled".

Also added az-boolean-param-names-convention for parameter names.

I wish I could have done both property and parameter names in one rule but that was too complicated.