### PR TITLE
Action in path does not need to be kebab-case

### DIFF
--- a/spectral.yaml
+++ b/spectral.yaml
@@ -422,7 +422,7 @@ rules:
       functionOptions:
         # Check each path segment individually and ignore param segments
         # Note: the ':' is only allowed in the final path segment
-        match: '^(\/([a-z][a-z0-9-]+|{[^}]+}))*\/([a-z][a-z0-9-]+|{[^}]*})?(:[a-z][a-z0-9-]+)?$'
+        match: '^(\/([a-z][a-z0-9-]+|{[^}]+}))*\/([a-z][a-z0-9-]+|{[^}]*})?(:[A-Za-z0-9]+)?$'
 
   # DO limit your URLs characters to 0-9 A-Z a-z - . _ ~ :
   az-path-characters:

--- a/test/path-case-convention.test.js
+++ b/test/path-case-convention.test.js
@@ -13,14 +13,12 @@ test('az-path-case-convention should find errors', () => {
     paths: {
       '/fooBar': {},
       '/foo-bar/{id}/barBaz': {},
-      '/foo/{bar}:bazQux': {},
     },
   };
   return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(3);
+    expect(results.length).toBe(2);
     expect(results[0].path.join('.')).toBe('paths./fooBar');
     expect(results[1].path.join('.')).toBe('paths./foo-bar/{id}/barBaz');
-    expect(results[2].path.join('.')).toBe('paths./foo/{bar}:bazQux');
   });
 });
 
@@ -32,7 +30,7 @@ test('az-path-case-convention should find no errors', () => {
       '/:foobar': {},
       '/abcdefghijklmnopqrstuvwxyz0123456789': {},
       '/a0-b1-c2/d3-e4-f5/ghi-jkl-mno/pqrstuvwxyz': {},
-      '/foo/{$#@&^}:bar-baz': {},
+      '/foo/{bar}:bazQux': {},
     },
   };
   return linter.run(oasDoc).then((results) => {


### PR DESCRIPTION
This PR makes a minor fix to the az-path-case-convention rule to relax the pattern for the action part, after a ":", to not require kebab-case or any particular case convention.