### PR TITLE
Allow format: uri for string types

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -312,6 +312,7 @@ The well-defined type/format combinations are:
 | uuid |  | from [autorest][autorest] |
 | base64url |  | from [autorest][autorest] |
 | url |  | from [autorest][autorest] |
+| uri |  | from [autorest][autorest] |
 | odata-query |  | from [autorest][autorest] |
 | certificate |  | from [autorest][autorest] |
 

--- a/functions/schema-type-and-format.js
+++ b/functions/schema-type-and-format.js
@@ -15,7 +15,7 @@ module.exports = function checkTypeAndFormat(schema, options, { path }) {
     // OAS-defined formats
     'byte', 'binary', 'date', 'date-time', 'password',
     // Additional formats recognized by autorest
-    'char', 'time', 'date-time-rfc1123', 'duration', 'uuid', 'base64url', 'url',
+    'char', 'time', 'date-time-rfc1123', 'duration', 'uuid', 'base64url', 'url', 'uri',
     'odata-query', 'certificate',
   ];
 

--- a/test/schema-type-and-format.test.js
+++ b/test/schema-type-and-format.test.js
@@ -227,6 +227,10 @@ test('az-schema-type-and-format should find no errors', () => {
         type: 'string',
         format: 'url',
       },
+      PropZZ2: {
+        type: 'string',
+        format: 'uri',
+      },
       ModelA: {
         type: 'object',
         properties: {


### PR DESCRIPTION
This PR makes a small change to the az-schema-type-and-format rule to allow `format: uri` for string types. Autorest accepts `format: uri` as equivalent to `format: url`.

It's also worth noting that "uri" has been added to the [OpenAPI formats registry](https://spec.openapis.org/registry/format/).

Tests and documentation have been updated.