### PR TITLE
Fix property default not allowed

### DIFF
--- a/functions/property-default-not-allowed.js
+++ b/functions/property-default-not-allowed.js
@@ -10,7 +10,7 @@ module.exports = function propertyDefaultNotAllowed(schema, options, { path }) {
 
   // eslint-disable-next-line no-restricted-syntax
   for (const prop of schema.required || []) {
-    if (schema.properties[prop]?.default) {
+    if (schema.properties?.[prop]?.default) {
       errors.push({
         message: `Schema property "${prop}" is required and cannot have a default`,
         path: [...path, 'properties', prop, 'default'],

--- a/test/property-default-not-allowed.test.js
+++ b/test/property-default-not-allowed.test.js
@@ -33,6 +33,18 @@ test('az-property-default-not-allowed should find errors', () => {
           },
         },
       },
+      '/path2': {
+        get: {
+          responses: {
+            200: {
+              description: 'OK',
+              schema: {
+                $ref: '#/definitions/AnotherModel',
+              },
+            },
+          },
+        },
+      },
     },
     definitions: {
       MyBodyModel: {
@@ -78,6 +90,20 @@ test('az-property-default-not-allowed should find errors', () => {
             default: 'baz',
           },
         },
+      },
+      AnotherModel: {
+        type: 'object',
+        required: ['foo'],
+        allOf: [
+          {
+            properties: {
+              foo: {
+                type: 'string',
+                default: 'qux',
+              },
+            },
+          },
+        ],
       },
     },
   };


### PR DESCRIPTION
This PR fixes a bug in the propertyDefaultNotAllowed function that attempted to reference into `properties` without first ensuring it was defined. The fix is to use optional chaining.  I also added a test (as the first commit) to reproduce the problem.