### PR TITLE
Fix az-property-type for oas3

### DIFF
--- a/spectral.yaml
+++ b/spectral.yaml
@@ -508,8 +508,8 @@ rules:
     message: Property should have a defined type.
     severity: warn
     resolved: false
-    # Exclude properties that contains allOf to avoid false positives.
-    given: $..properties[?(@object() && @.$ref == undefined && @.allOf == undefined)]
+    # Exclude properties that contains allOf or oneOf or anyOf to avoid false positives.
+    given: $..properties[?(@object() && @.$ref == undefined && @.allOf == undefined && @.oneOf == undefined && @.anyOf == undefined)]
     then:
       field: type
       function: truthy


### PR DESCRIPTION
This PR fixes the az-property-type rule to avoid false positives in oas3 specs using oneOf and/or anyOf.

Fixes #127.