### PR TITLE
Collection of little fixes

### DIFF
--- a/functions/pagination-response.js
+++ b/functions/pagination-response.js
@@ -54,14 +54,16 @@ module.exports = (operation, _opts, paths) => {
     // Check nextLink property
     const nextLinkName = operation['x-ms-pageable'].nextLinkName || 'nextLink';
     if (responseSchema.properties && nextLinkName in responseSchema.properties) {
-      if (responseSchema.properties[nextLinkName].type !== 'string') {
+      const nextLinkProperty = responseSchema.properties[nextLinkName];
+      if (nextLinkProperty.type !== 'string') {
         errors.push({
           message: `\`${nextLinkName}\` property in pageable response should be type: string`,
           path: [...path, 'responses', resp, 'schema', 'properties', nextLinkName, 'type'],
         });
-      } else if (responseSchema.properties[nextLinkName].format !== 'url') {
+      } else if (nextLinkProperty.format !== 'uri' && nextLinkProperty.format !== 'url') {
+        // Allow "uri" or "url", but prefer "uri"
         errors.push({
-          message: `\`${nextLinkName}\` property in pageable response should be format: url`,
+          message: `\`${nextLinkName}\` property in pageable response should be format: uri`,
           path: [...path, 'responses', resp, 'schema', 'properties', nextLinkName, 'format'],
         });
       }

--- a/functions/param-names.js
+++ b/functions/param-names.js
@@ -32,7 +32,8 @@ module.exports = (targetVal, _opts, paths) => {
       ];
     }
   } else if (targetVal.in === 'header') {
-    if (!targetVal.name.match(/^[A-Za-z][a-z0-9]*(-[A-Za-z][a-z0-9]*)*$/)) {
+    // Tiny fix to allow for ID suffixes on header parameters e.g. Repeatability-Request-ID
+    if (!targetVal.name.match(/^[A-Za-z][a-z0-9]*(-[A-Za-z][a-z0-9]*)*(-ID)?$/)) {
       return [
         {
           message: `header parameter name "${targetVal.name}" should be kebab case.`,

--- a/functions/readonly-in-response-schema.js
+++ b/functions/readonly-in-response-schema.js
@@ -15,7 +15,7 @@ function getRequestSchemas(oasDoc) {
   const getOps = ({put, post, patch}) => [put, post, patch];
   const topLevelRequestSchemas = Object.values(oasDoc.paths || {})
     .flatMap(getOps).filter(Boolean)
-    .flatMap(({parameters}) => parameters.filter(({in: location}) => location === 'body'))
+    .flatMap(({parameters}) => parameters?.filter(({in: location}) => location === 'body') || [])
     .flatMap(({schema}) => (schema ? [schema] : []))
     .filter(({$ref}) => $ref && $ref.match(/^#\/definitions\//))
     .map(({$ref}) => $ref.replace(/^#\/definitions\//, ''));

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -377,6 +377,8 @@ rules:
     description: All parameters should have a description.
     message: Parameter should have a description.
     severity: warn
+    # In oas3 the description might be within the schema -- should not flag those
+    formats: ['oas2']
     given:
     - $.paths[*].parameters.*
     - $.paths.*[get,put,post,patch,delete,options,head].parameters.*

--- a/test/pagination-response.test.js
+++ b/test/pagination-response.test.js
@@ -244,7 +244,7 @@ test('az-pagination-response should find errors in nextLink property', () => {
     expect(results[0].path.join('.')).toBe('paths./test5.get.responses.200.schema.properties.nextLink.type');
     expect(results[0].message).toBe('`nextLink` property in pageable response should be type: string');
     expect(results[1].path.join('.')).toBe('paths./test5a.get.responses.200.schema.properties.nextLink');
-    expect(results[1].message).toBe('`nextLink` property in pageable response should be format: url');
+    expect(results[1].message).toBe('`nextLink` property in pageable response should be format: uri');
     expect(results[2].path.join('.')).toBe('paths./test6.get.responses.200.schema.required');
     expect(results[2].message).toBe('`nextPage` property in pageable response should be optional.');
     expect(results[3].path.join('.')).toBe('paths./test7.get.responses.200.schema.properties');
@@ -294,7 +294,7 @@ test('az-pagination-response should find no errors', () => {
                   },
                   nextLink: {
                     type: 'string',
-                    format: 'url',
+                    format: 'uri',
                   },
                 },
                 required: ['value'],

--- a/test/readonly-in-response-schema.test.js
+++ b/test/readonly-in-response-schema.test.js
@@ -111,6 +111,15 @@ test('az-readonly-in-response-schema should not find errors', () => {
           },
         },
       },
+      '/test3': {
+        post: {
+          responses: {
+            200: {
+              description: 'Success',
+            },
+          },
+        },
+      },
     },
     definitions: {
       Model1: {


### PR DESCRIPTION
This PR contains a collection of little fixes I have been accumulating in my local repo:

- Allow `nextLink` format to be either `url` or `uri`
- Allow uppercase "ID" suffixes on header parameters e.g. Repeatability-Request-ID 
- Fix readonly-in-response function to properly handle operation with no parameters.