### PR TITLE
Add az-put-request-and-response-body rule with test and docs

### DIFF
--- a/docs/azure-ruleset.md
+++ b/docs/azure-ruleset.md
@@ -246,6 +246,10 @@ Put operations are typically issued on a specific resource whose id is the final
 Therefore, it is uncommon for a put operation to be defined on a path that does not have a path parameter
 as the final path segment.
 
+### az-put-request-and-response-body
+
+A PUT operation should use the same schema for the request and response body [ref](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#rest-response-body-is-resource-schema).
+
 ### az-readonly-in-response-schema
 
 Don't mark properties as `readOnly: true` in schemas that are only used within response bodies.

--- a/functions/put-request-and-response-body.js
+++ b/functions/put-request-and-response-body.js
@@ -1,0 +1,26 @@
+// The put request and response body should be the same.
+
+// "given" is a put operation object.
+// This function assumes it is running on an unresolved doc.
+module.exports = (putOperation, _opts, paths) => {
+  if (putOperation === null || typeof putOperation !== 'object') {
+    return [];
+  }
+  const path = paths.path || paths.target || [];
+
+  const errors = [];
+
+  // resource schema is create operation response schema
+  const responseBodyRef = putOperation.responses?.['201']?.schema?.$ref
+                          || putOperation.responses?.['200']?.schema?.$ref;
+  const requestBodyRef = putOperation.parameters?.find((param) => param.in === 'body')?.schema?.$ref;
+
+  if (responseBodyRef && requestBodyRef && responseBodyRef !== requestBodyRef) {
+    errors.push({
+      message: 'A PUT operation should use the same schema for the request and response body.',
+      path,
+    });
+  }
+
+  return errors;
+};

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -16,6 +16,7 @@ functions:
   - patch-content-type
   - path-param-schema
   - path-param-names
+  - put-request-and-response-body
   - property-default-not-allowed
   - readonly-in-response-schema
   - security-definitions
@@ -548,6 +549,16 @@ rules:
       function: pattern
       functionOptions:
         match: '/\}$/'
+
+  az-put-request-and-response-body:
+    description: A PUT operation should use the same schema for the request and response body.
+    severity: info
+    formats: ['oas2']
+    # Run on the unresolved document so that we compare the $ref'ed schema
+    resolved: false
+    given: $.paths[*].put
+    then:
+      function: put-request-and-response-body
 
   az-readonly-in-response-schema:
     description: Properties in response-only schemas should not be marked as readOnly true

--- a/test/put-request-and-response-body.test.js
+++ b/test/put-request-and-response-body.test.js
@@ -1,0 +1,104 @@
+const { linterForRule } = require('./utils');
+
+let linter;
+
+beforeAll(async () => {
+  linter = await linterForRule('az-put-request-and-response-body');
+  return linter;
+});
+
+test('az-put-request-and-response-body should find errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1/{id}': {
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            type: 'string',
+          },
+        ],
+        put: {
+          parameters: [
+            {
+              name: 'body',
+              in: 'body',
+              schema: {
+                $ref: '#/definitions/This',
+              },
+            },
+          ],
+          responses: {
+            201: {
+              description: 'Created',
+              schema: {
+                $ref: '#/definitions/That',
+              },
+            },
+          },
+        },
+      },
+    },
+    definitions: {
+      This: {
+        description: 'This',
+        type: 'object',
+      },
+      That: {
+        description: 'That',
+        type: 'object',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1);
+    expect(results[0].path.join('.')).toBe('paths./test1/{id}.put');
+    expect(results[0].message).toBe('A PUT operation should use the same schema for the request and response body.');
+  });
+});
+
+test('az-put-request-and-response-body should find no errors', () => {
+  const oasDoc = {
+    swagger: '2.0',
+    paths: {
+      '/test1/{id}': {
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            type: 'string',
+          },
+        ],
+        put: {
+          parameters: [
+            {
+              name: 'body',
+              in: 'body',
+              schema: {
+                $ref: '#/definitions/This',
+              },
+            },
+          ],
+          responses: {
+            201: {
+              description: 'Created',
+              schema: {
+                $ref: '#/definitions/This',
+              },
+            },
+          },
+        },
+      },
+    },
+    definitions: {
+      This: {
+        description: 'This',
+        type: 'object',
+      },
+    },
+  };
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR adds the az-put-request-and-response-body rule, which checks PUT operations to ensure that the schema for the request body matches the schema for the success (200 or 201) response body.