### PR TITLE
Improve az-patch-patch rule

### DIFF
--- a/spectral.yaml
+++ b/spectral.yaml
@@ -429,11 +429,10 @@ rules:
     description: Patch on a path that does not end with a path parameter is uncommon.
     severity: info
     formats: ['oas2', 'oas3']
-    given: $.paths[*].patch^~
+    given: $.paths[?(!@path.match(/\}']$/))]
     then:
-      function: pattern
-      functionOptions:
-        match: '/\}$/'
+      field: patch
+      function: falsy
 
   # Static path segments should be kebab-case
   az-path-case-convention:


### PR DESCRIPTION
This PR makes a small tweak to the az-patch-path rule so that the resulting `path` for a violation is the `patch` operation and not the whole pathItem.