### PR TITLE
Enable workflow dispatch

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,6 +6,7 @@ name: Node.js CI
 on:
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
CoPilot says I need this line to enable triggering the workflow with the gh CLI, which I need to do because the GitHub workflows pages is not showing me a "Re-run jobs" button (so frustrating).